### PR TITLE
Route functions now process Ctrl-click correctly

### DIFF
--- a/.obelisk/impl/github.json
+++ b/.obelisk/impl/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "obelisk",
-  "branch": "master",
+  "branch": "ao-block-explorer-test",
   "private": false,
-  "rev": "7ad33cbe3e84b209e83c505ce25486445bbd602e",
-  "sha256": "0dlk8y6rxc87crw7764zq2py7nqn38lw496ca1y893m9gdq8qdkz"
+  "rev": "c139eaecdd210797986065f428a37bef00d50c76",
+  "sha256": "0rml3p7i66714f2gwgdyy5k0m0i86mnxxilfj5rarq6bd6l72dq2"
 }

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -124,7 +124,7 @@ networkDispatch route ndbs netId = prerender_ blank $ do
 chainRouteHandler
   :: (MonadApp r t m, Monad (Client m), MonadJSM (Performable m), HasJSContext (Performable m),
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
-      Prerender js t m
+      Prerender js t m, RouteClick t m
      )
   => ServerInfo
   -> NetId
@@ -362,7 +362,7 @@ mkSearchRoute netId str EventSearch = mkEventSearchRoute netId str Nothing
 mainPageWidget
   :: forall js r t m. (MonadAppIO r t m, Prerender js t m,
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
-      DomBuilderSpace m ~ GhcjsDomSpace)
+      DomBuilderSpace m ~ GhcjsDomSpace, RouteClick t m)
   => NetId
   -> Maybe BlockHeight
   -> App r t m ()
@@ -458,7 +458,7 @@ mainPageWidget netId (Just height) = do
 searchPageWidget
   :: forall js r t m. (MonadAppIO r t m, Prerender js t m,
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
-      DomBuilderSpace m ~ GhcjsDomSpace)
+      DomBuilderSpace m ~ GhcjsDomSpace, RouteClick t m)
   => NetId
   -> App r t m ()
 searchPageWidget netId = do
@@ -486,7 +486,8 @@ chainDifficulty cid bt =
 rowsWidget
   :: (MonadAppIO r t m, Prerender js t m,
       HasJSContext (Performable m),
-      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m)
+      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
+      RouteClick t m)
   => Dynamic t TickInfo
   -> AllGraphs
   -> Dynamic t (Maybe BlockRef)
@@ -502,7 +503,8 @@ rowsWidget ti gis hoveredBlock maxNumChains (Down bh) cs = do
 blockHeightRow
   :: (MonadAppIO r t m, Prerender js t m,
       HasJSContext (Performable m),
-      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m)
+      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
+      RouteClick t m)
   => Dynamic t TickInfo
   -> AllGraphs
   -> Dynamic t (Maybe BlockRef)
@@ -526,7 +528,8 @@ blockHeightRow ti gis hoveredBlock maxNumChains height headers = do
 blockWidget0
   :: (MonadAppIO r t m, Prerender js t m,
       HasJSContext (Performable m),
-      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m)
+      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
+      RouteClick t m)
   => Dynamic t TickInfo
   -> AllGraphs
   -> Dynamic t (Maybe BlockRef)

--- a/frontend/src/Frontend/Page/Block.hs
+++ b/frontend/src/Frontend/Page/Block.hs
@@ -51,7 +51,8 @@ import           Frontend.Page.Transaction
 blockHashWidget
   :: (MonadApp r t m, MonadJSM (Performable m), HasJSContext (Performable m),
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m, Monad (Client m),
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => ServerInfo
   -> NetId
@@ -71,7 +72,8 @@ blockHashWidget si netId cid = do
 blockHeightWidget
   :: (MonadApp r t m, MonadJSM (Performable m), HasJSContext (Performable m),
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m, Monad (Client m),
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => ServerInfo
   -> NetId
@@ -91,7 +93,8 @@ blockHeightWidget si netId cid = do
 blockLink
   :: (RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
       DomBuilder t m,
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> ChainId
@@ -104,7 +107,8 @@ blockLink netId chainId height linkText =
 blockHashLink
   :: (RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
       DomBuilder t m,
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> ChainId
@@ -117,7 +121,8 @@ blockHashLink netId chainId blockHash linkText =
 blockPageNoPayload
   :: (MonadApp r t m, MonadJSM (Performable m), HasJSContext (Performable m),
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m, Monad (Client m),
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> ChainwebHost
@@ -141,7 +146,8 @@ blockHeaderPage
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
       HasJSContext (Performable m),
       MonadJSM (Performable m),
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> ChainwebHost
@@ -188,7 +194,8 @@ blockHeaderPage netId h c (bh, bhBinBase64) bp resolveOrphan = do
 blockPayloadWidget
   :: (MonadApp r t m,
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> ChainId
@@ -211,7 +218,8 @@ blockPayloadWidget netId c bh bp = do
 blockPayloadWithOutputsWidget
   :: (MonadApp r t m,
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> ChainId

--- a/frontend/src/Frontend/Page/Common.hs
+++ b/frontend/src/Frontend/Page/Common.hs
@@ -99,6 +99,7 @@ transactionsLink
      , RouteToUrl (R FrontendRoute) m
      , SetRoute t (R FrontendRoute) m
      , Prerender js t m
+     , RouteClick t m
      )
   => NetId
   -> ChainId
@@ -117,6 +118,7 @@ renderMetaData
        , RouteToUrl (R FrontendRoute) m
        , SetRoute t (R FrontendRoute) m
        , Prerender js t m
+       , RouteClick t m
        )
     => NetId
     -> ChainId

--- a/frontend/src/Frontend/Page/ReqKey.hs
+++ b/frontend/src/Frontend/Page/ReqKey.hs
@@ -67,6 +67,7 @@ requestKeyWidget
        , Prerender js t m
        , RouteToUrl (R FrontendRoute) m
        , SetRoute t (R FrontendRoute) m
+       , RouteClick t m
        )
     => ServerInfo
     -> NetId
@@ -118,6 +119,7 @@ requestKeyResultPage
        , RouteToUrl (R FrontendRoute) m
        , SetRoute t (R FrontendRoute) m
        , Prerender js t m
+       , RouteClick t m
        )
     => NetId
     -> ChainId

--- a/frontend/src/Frontend/Page/Transaction.hs
+++ b/frontend/src/Frontend/Page/Transaction.hs
@@ -50,6 +50,7 @@ transactionPage
      , RouteToUrl (R FrontendRoute) m
      , SetRoute t (R FrontendRoute) m
      , Prerender js t m
+     , RouteClick t m
      )
   => NetId
   -> ChainId

--- a/frontend/src/Frontend/Page/TxDetail.hs
+++ b/frontend/src/Frontend/Page/TxDetail.hs
@@ -50,6 +50,7 @@ txDetailWidget
        , Prerender js t m
        , RouteToUrl (R FrontendRoute) m
        , SetRoute t (R FrontendRoute) m
+       , RouteClick t m
        )
     => NetId
     -> App T.Text t m ()
@@ -76,6 +77,7 @@ txDetailPage
      , HasJSContext (Performable m)
      , MonadJSM (Performable m)
      , Prerender js t m
+     , RouteClick t m
      )
   => NetId
   -> ChainwebVersion

--- a/frontend/src/Frontend/Transactions.hs
+++ b/frontend/src/Frontend/Transactions.hs
@@ -47,7 +47,8 @@ recentTransactions
       HasJSContext (Performable m), MonadJSM (Performable m),
       DomBuilder t m, PerformEvent t m, TriggerEvent t m, PostBuild t m,
       Prerender js t m,
-      MonadHold t m)
+      MonadHold t m,
+      RouteClick t m)
   => Int
   -> RecentTxs
   -> m ()
@@ -78,6 +79,7 @@ transactionSearch
        , HasJSContext (Performable m)
        , RouteToUrl (R FrontendRoute) m
        , SetRoute t (R FrontendRoute) m
+       , RouteClick t m
        )
     => App (Map Text (Maybe Text)) t m ()
 transactionSearch = do
@@ -139,6 +141,7 @@ eventSearch
        , HasJSContext (Performable m)
        , RouteToUrl (R FrontendRoute) m
        , SetRoute t (R FrontendRoute) m
+       , RouteClick t m
        )
     => App (Map Text (Maybe Text)) t m ()
 eventSearch = do
@@ -189,7 +192,8 @@ uiPagination = do
 
 txTable
   :: (DomBuilder t m, Prerender js t m,
-      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m)
+      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
+      RouteClick t m)
   => NetId
   -> Text
   -> [TxSummary]
@@ -245,7 +249,8 @@ txTable net hdr txs = do
 
 evTable
   :: (DomBuilder t m, Prerender js t m,
-      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m)
+      RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
+      RouteClick t m)
   => NetId
   -> [EventDetail]
   -> m ()
@@ -294,7 +299,8 @@ senderWidget tx = text $
 txDetailLink
   :: (RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m,
       DomBuilder t m,
-      Prerender js t m
+      Prerender js t m,
+      RouteClick t m
      )
   => NetId
   -> Text


### PR DESCRIPTION
Various route link functions such as routeLink, dynRouteLink created anchor tags that did not support opening a new tab when Ctrl-clicked.

This PR solves that issue by taking a branch of Obelisk that has already fixed the issue internally.