### PR TITLE
Restrict block-height range in transfers URL

### DIFF
--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -112,7 +112,7 @@ accountParamsEncoder = unsafeMkEncoder $ EncoderImpl dec enc where
       M.singleton "token" (Just $ apToken ap) 
       <> maybe mempty (M.singleton "chain" . Just . T.pack . show)  (apChain ap)
       <> maybe mempty (M.singleton "minheight" . Just . T.pack . show) (apMinHeight ap)
-      <> maybe mempty (M.singleton "maxHeight" . Just . T.pack . show) (apMaxHeight ap)
+      <> maybe mempty (M.singleton "maxheight" . Just . T.pack . show) (apMaxHeight ap)
 
 data NetRoute :: * -> * where
   NetRoute_Chainweb :: NetRoute ()

--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -85,25 +85,25 @@ accountParamsEncoder = unsafeMkEncoder $ EncoderImpl dec enc where
          Just (Just chainIdTxt) -> case readMaybe @Integer (T.unpack chainIdTxt) of
              Nothing -> Left $ "Chain \"" <> chainIdTxt <> "\" must be an int"
              Just cid -> Right $ Just cid
-      minHeight <- case M.lookup "min-height" params of
+      minheight <- case M.lookup "minheight" params of
         Nothing -> return Nothing
-        Just Nothing -> Left "Expected a value for the min-height parameter!"
-        Just (Just minHeightTxt) -> case readMaybe @Integer (T.unpack minHeightTxt) of
-           Nothing -> Left $ "min-height \"" <> minHeightTxt <> "\" must be an int"
-           Just minHeight -> Right $ Just minHeight
-      maxHeight <- case M.lookup "max-height" params of
+        Just Nothing -> Left "Expected a value for the minheight parameter!"
+        Just (Just minheightTxt) -> case readMaybe @Integer (T.unpack minheightTxt) of
+           Nothing -> Left $ "minheight \"" <> minheightTxt <> "\" must be an int"
+           Just minheight -> Right $ Just minheight
+      maxheight <- case M.lookup "maxheight" params of
         Nothing -> return Nothing
-        Just Nothing -> Left "Expected a value for the max-height parameter!"
-        Just (Just maxHeightTxt) -> case readMaybe @Integer (T.unpack maxHeightTxt) of
-           Nothing -> Left $ "max-height \"" <> maxHeightTxt <> "\" must be an int"
-           Just maxHeight -> Right $ Just maxHeight
+        Just Nothing -> Left "Expected a value for the maxheight parameter!"
+        Just (Just maxheightTxt) -> case readMaybe @Integer (T.unpack maxheightTxt) of
+           Nothing -> Left $ "maxheight \"" <> maxheightTxt <> "\" must be an int"
+           Just maxheight -> Right $ Just maxheight
       return AccountParams
          {
            apToken = token
          , apAccount = account
          , apChain = chain
-         , apMinHeight = minHeight
-         , apMaxHeight = maxHeight
+         , apMinHeight = minheight
+         , apMaxHeight = maxheight
          }
     [] -> Left "Something about no account name in the url."
     _ -> Left "Something about unexpected path segments after the account name."
@@ -111,8 +111,8 @@ accountParamsEncoder = unsafeMkEncoder $ EncoderImpl dec enc where
     params = 
       M.singleton "token" (Just $ apToken ap) 
       <> maybe mempty (M.singleton "chain" . Just . T.pack . show)  (apChain ap)
-      <> maybe mempty (M.singleton "min-height" . Just . T.pack . show) (apMinHeight ap)
-      <> maybe mempty (M.singleton "max-height" . Just . T.pack . show) (apMaxHeight ap)
+      <> maybe mempty (M.singleton "minheight" . Just . T.pack . show) (apMinHeight ap)
+      <> maybe mempty (M.singleton "maxHeight" . Just . T.pack . show) (apMaxHeight ap)
 
 data NetRoute :: * -> * where
   NetRoute_Chainweb :: NetRoute ()

--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -111,6 +111,8 @@ accountParamsEncoder = unsafeMkEncoder $ EncoderImpl dec enc where
     params = 
       M.singleton "token" (Just $ apToken ap) 
       <> maybe mempty (M.singleton "chain" . Just . T.pack . show)  (apChain ap)
+      <> maybe mempty (M.singleton "min-height" . Just . T.pack . show) (apMinHeight ap)
+      <> maybe mempty (M.singleton "max-height" . Just . T.pack . show) (apMaxHeight ap)
 
 data NetRoute :: * -> * where
   NetRoute_Chainweb :: NetRoute ()

--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -66,6 +66,8 @@ data AccountParams = AccountParams
   { apToken :: T.Text
   , apAccount :: T.Text
   , apChain :: Maybe Integer
+  , apMinHeight :: Maybe Integer
+  , apMaxHeight :: Maybe Integer
   }
 
 accountParamsEncoder :: Applicative check =>
@@ -83,11 +85,25 @@ accountParamsEncoder = unsafeMkEncoder $ EncoderImpl dec enc where
          Just (Just chainIdTxt) -> case readMaybe @Integer (T.unpack chainIdTxt) of
              Nothing -> Left $ "Chain \"" <> chainIdTxt <> "\" must be an int"
              Just cid -> Right $ Just cid
+      minHeight <- case M.lookup "min-height" params of
+        Nothing -> return Nothing
+        Just Nothing -> Left "Expected a value for the min-height parameter!"
+        Just (Just minHeightTxt) -> case readMaybe @Integer (T.unpack minHeightTxt) of
+           Nothing -> Left $ "min-height \"" <> minHeightTxt <> "\" must be an int"
+           Just minHeight -> Right $ Just minHeight
+      maxHeight <- case M.lookup "max-height" params of
+        Nothing -> return Nothing
+        Just Nothing -> Left "Expected a value for the max-height parameter!"
+        Just (Just maxHeightTxt) -> case readMaybe @Integer (T.unpack maxHeightTxt) of
+           Nothing -> Left $ "max-height \"" <> maxHeightTxt <> "\" must be an int"
+           Just maxHeight -> Right $ Just maxHeight
       return AccountParams
          {
            apToken = token
          , apAccount = account
          , apChain = chain
+         , apMinHeight = minHeight
+         , apMaxHeight = maxHeight
          }
     [] -> Left "Something about no account name in the url."
     _ -> Left "Something about unexpected path segments after the account name."

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "38eb85b5395b575aa2efeff91fbfeb5cb3d494ce",
-  "sha256": "10papx5p14y8192gc8mi1dq89vxhil8fci5j3skf5ijralxsj8f4"
+  "rev": "8a4731c2875753617ccd2b573cf726fa100c6053",
+  "sha256": "05zlllv86zqi56alxci37n6ddaqsl1a1bq3yxn5zf1py779kp3ii"
 }

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -366,7 +366,7 @@ mkSearchRoute :: NetId -> Text -> SearchType -> R FrontendRoute
 mkSearchRoute netId str RequestKeySearch = mkReqKeySearchRoute netId str
 mkSearchRoute netId str TxSearch = mkTxSearchRoute netId str Nothing
 mkSearchRoute netId str EventSearch = mkEventSearchRoute netId str Nothing
-mkSearchRoute netId str AccountSearch = mkAccountRoute netId "coin" str Nothing
+mkSearchRoute netId str AccountSearch = mkAccountRoute netId "coin" str Nothing Nothing Nothing
 
 mainPageWidget
   :: forall js r t m. (MonadAppIO r t m, Prerender js t m,

--- a/frontend/src/Frontend/Accounts.hs
+++ b/frontend/src/Frontend/Accounts.hs
@@ -158,7 +158,7 @@ accountInfo token account mInfos = do
             totalCount = length infos
             balances = foldl' addTo mempty good
         let linkText = "View most recent transfers associated to this account."
-        el "p" $ routeLink (mkTransferViewRoute n account token Nothing) (text linkText)
+        el "p" $ routeLink (mkTransferViewRoute n account token Nothing Nothing Nothing) (text linkText)
         el "p" $ do
           text $ "Got data from " <> tshow goodCount <> " chains"
           when (totalCount > goodCount) $
@@ -185,7 +185,7 @@ accountInfo token account mInfos = do
                 let mkAttrs open = "style" =: if open then  "cursor: auto;" else "display: none;"
                 elDynAttr "tr" (mkAttrs <$> openDyn) $ do
                   el "td" blank
-                  el "td" $ routeLink (mkTransferViewRoute n account "coin" (Just chain)) $
+                  el "td" $ routeLink (mkTransferViewRoute n account "coin" (Just chain) Nothing Nothing) $
                     text $ "Chain " <> T.pack (show chain)
                   el "td" $ text $ tshow bal
 
@@ -208,20 +208,24 @@ limParam = "lim"
 pageParam :: Text
 pageParam = "page"
 
-mkTransferViewRoute :: NetId -> Text -> Text -> Maybe Integer -> R FrontendRoute
-mkTransferViewRoute netId account token chainid =
+mkTransferViewRoute :: NetId -> Text -> Text -> Maybe Integer -> Maybe Integer -> Maybe Integer -> R FrontendRoute
+mkTransferViewRoute netId account token chainid minHeight maxHeight =
   mkNetRoute netId $ NetRoute_TransferSearch :/ AccountParams
     { apToken = token
     , apAccount = account
     , apChain = chainid
+    , apMinHeight = minHeight
+    , apMaxHeight = maxHeight
     }
 
-mkAccountRoute :: NetId -> Text -> Text -> Maybe Integer -> R FrontendRoute
-mkAccountRoute netId token account chain = mkNetRoute netId $
+mkAccountRoute :: NetId -> Text -> Text -> Maybe Integer -> Maybe Integer -> Maybe Integer -> R FrontendRoute
+mkAccountRoute netId token account chain minHeight maxHeight = mkNetRoute netId $
   NetRoute_AccountSearch :/ AccountParams
     { apToken = token
     , apAccount = account
     , apChain = chain
+    , apMinHeight = minHeight
+    , apMaxHeight = maxHeight
     }
 
 accountSearchLink
@@ -235,4 +239,4 @@ accountSearchLink
   -> Text
   -> m ()
 accountSearchLink netId token account linkText =
-  routeLink (mkAccountRoute netId token account Nothing) $ text linkText
+  routeLink (mkAccountRoute netId token account Nothing Nothing Nothing) $ text linkText

--- a/frontend/src/Frontend/ChainwebApi.hs
+++ b/frontend/src/Frontend/ChainwebApi.hs
@@ -475,9 +475,11 @@ searchTxs
     -> Dynamic t (Maybe Limit)
     -> Dynamic t (Maybe Offset)
     -> Dynamic t (QParam Text)
+    -> Dynamic t (QParam Int)
+    -> Dynamic t (QParam Int)
     -> Event t ()
     -> m (Event t (Either Text (Bool,[TxSummary])))
-searchTxs nc lim off needle evt = do
+searchTxs nc lim off needle minHeight maxHeight evt = do
     case _netConfig_dataHost nc of
       Nothing -> return never
       Just dh -> do
@@ -487,7 +489,7 @@ searchTxs nc lim off needle evt = do
                 (Proxy :: Proxy (LooperTag TxSummary ()))
                 (constDyn $ mkDataUrl dh)
                 nextHeaderOpts
-        txResp <- requestLooper (\limm offf nextToken evt' -> go limm offf needle nextToken evt') lim off evt
+        txResp <- requestLooper (\limm offf nextToken evt' -> go limm offf needle minHeight maxHeight nextToken evt') lim off evt
         return $ handleLooperResults <$> txResp
 
 handleLooperResults :: Either (ReqResult t [result]) (LooperTag result callerTag) -> Either Text (Bool, [result])
@@ -574,9 +576,10 @@ searchEvents
     -> Dynamic t (QParam EventName)
     -> Dynamic t (QParam EventModuleName)
     -> Dynamic t (QParam BlockHeight)
+    -> Dynamic t (QParam BlockHeight)
     -> Event t ()
     -> m (Event t (Either Text (Bool, [EventDetail])))
-searchEvents nc lim off search param name moduleName minHeight evt = do
+searchEvents nc lim off search param name moduleName minHeight maxHeight evt = do
     case _netConfig_dataHost nc of
       Nothing -> return never
       Just dh -> do
@@ -586,7 +589,7 @@ searchEvents nc lim off search param name moduleName minHeight evt = do
                 (Proxy :: Proxy (LooperTag EventDetail ()))
                 (constDyn $ mkDataUrl dh)
                 nextHeaderOpts
-        txResp <- requestLooper (\limm offf nextToken evt' -> go limm offf search param name moduleName minHeight nextToken evt') lim off evt
+        txResp <- requestLooper (\limm offf nextToken evt' -> go limm offf search param name moduleName minHeight maxHeight nextToken evt') lim off evt
         return $ handleLooperResults <$> txResp
 
 
@@ -636,10 +639,12 @@ getTransfers
     -> Dynamic t (Either Text Text) -- Account Name
     -> Dynamic t (QParam Text) -- Token
     -> Dynamic t (QParam ChainId)
+    -> Dynamic t (QParam Int)
+    -> Dynamic t (QParam Int)
     -> Dynamic t (QParam NextToken)
     -> Event t ()
     -> m (Event t (Either TransferError ([TransferDetail], Maybe NextToken)))
-getTransfers nc lim off account token chain nextToken evt = do
+getTransfers nc lim off account token chain minHeight maxHeight nextToken evt = do
     case _netConfig_dataHost nc of
       Nothing -> return never
       Just dh -> do
@@ -649,7 +654,7 @@ getTransfers nc lim off account token chain nextToken evt = do
                 (Proxy :: Proxy ())
                 (constDyn $ mkDataUrl dh)
                 nextHeaderOpts
-        trResp <- go account token chain lim off nextToken evt
+        trResp <- go account token chain minHeight maxHeight lim off nextToken evt
         return $ go_ <$> trResp
   where
     go_ = \case

--- a/frontend/src/Frontend/Page/Block.hs
+++ b/frontend/src/Frontend/Page/Block.hs
@@ -191,6 +191,8 @@ mkCoinAccountSearchRoute netId account = mkNetRoute netId $
     { apToken = "coin"
     , apAccount = account
     , apChain = Nothing
+    , apMinHeight = Nothing
+    , apMaxHeight = Nothing
     }
 
 blockPayloadWidget

--- a/frontend/src/Frontend/Transactions.hs
+++ b/frontend/src/Frontend/Transactions.hs
@@ -97,7 +97,7 @@ transactionSearch = do
         res <- searchTxs nc
                  (constDyn $ Just $ Limit itemsPerPage)
                  (Just . Offset . (*itemsPerPage) . pred <$> page)
-                 (QParamSome <$> needle) newSearch
+                 (QParamSome <$> needle) (constDyn QNone) (constDyn QNone) newSearch
 
         divClass "ui pagination menu" $ do
           let setSearchRoute f e = setRoute $
@@ -153,6 +153,7 @@ eventSearch = do
             (Just . Offset . (*itemsPerPage) . pred <$> page)
             (QParamSome <$> needle)
             (constDyn QNone) 
+            (constDyn QNone)
             (constDyn QNone)
             (constDyn QNone)
             (constDyn QNone)

--- a/frontend/src/Frontend/Transfer.hs
+++ b/frontend/src/Frontend/Transfer.hs
@@ -28,6 +28,7 @@ import           Obelisk.Route.Frontend
 import           Reflex.Dom.Core hiding (Value)
 import           Reflex.Network
 import           Servant.Common.Req hiding (note)
+import           Text.Printf (printf)
 ------------------------------------------------------------------------------
 import           Chainweb.Api.ChainId
 import           Chainweb.Api.StringEncoded
@@ -118,6 +119,17 @@ transferWidget AccountParams{..} nc = do
               tfield "Token" $ text apToken
               tfield "Account" $ accountSearchLink n apToken apAccount apAccount
               maybe (pure ()) (\cid -> tfield "Chain ID" $ text $ tshow cid) apChain
+              case (apMinHeight, apMaxHeight) of
+                (Nothing, Nothing) -> pure ()
+                (Nothing, Just maxHeight) -> do
+                  let rangeText = T.pack $ printf "Possibly genesis until height=%d" maxHeight
+                  tfield "Block Height Range" $ text rangeText
+                (Just minHeight, Nothing) -> do
+                  let rangeText = T.pack $ printf "From height=%d to present time" minHeight
+                  tfield "Block Height Range" $ text rangeText
+                (Just minHeight, Just maxHeight) -> do
+                  let rangeText = T.pack $ printf "%d-%d" minHeight maxHeight
+                  tfield "Block Height Range" $ text rangeText
           elAttr "div" ("style" =: "display: grid") $ mdo
             t <- elClass "table" "ui celled table" $ do
               el "thead" $ el "tr" $ do

--- a/frontend/src/Frontend/Transfer.hs
+++ b/frontend/src/Frontend/Transfer.hs
@@ -233,6 +233,8 @@ mkTransferSearchRoute netId account token = mkNetRoute netId $
     { apToken = token
     , apAccount = account
     , apChain = Nothing
+    , apMinHeight = Nothing
+    , apMaxHeight = Nothing
     }
 
 getTransferDetail :: Text -> Maybe [TransferDetail]

--- a/frontend/src/Frontend/Transfer.hs
+++ b/frontend/src/Frontend/Transfer.hs
@@ -119,17 +119,10 @@ transferWidget AccountParams{..} nc = do
               tfield "Token" $ text apToken
               tfield "Account" $ accountSearchLink n apToken apAccount apAccount
               maybe (pure ()) (\cid -> tfield "Chain ID" $ text $ tshow cid) apChain
-              case (apMinHeight, apMaxHeight) of
-                (Nothing, Nothing) -> pure ()
-                (Nothing, Just maxHeight) -> do
-                  let rangeText = T.pack $ printf "Possibly genesis until height=%d" maxHeight
-                  tfield "Block Height Range" $ text rangeText
-                (Just minHeight, Nothing) -> do
-                  let rangeText = T.pack $ printf "From height=%d to present time" minHeight
-                  tfield "Block Height Range" $ text rangeText
-                (Just minHeight, Just maxHeight) -> do
-                  let rangeText = T.pack $ printf "%d-%d" minHeight maxHeight
-                  tfield "Block Height Range" $ text rangeText
+              let rangeText = T.pack $ printf "From %s down to at most %s"
+                    (maybe "PRESENT TIME" show apMaxHeight)
+                    (maybe "POSSIBLY GENESIS" show apMinHeight)
+              when (isJust apMaxHeight || isJust apMinHeight) $ tfield "Height Range" $ text rangeText
           elAttr "div" ("style" =: "display: grid") $ mdo
             t <- elClass "table" "ui celled table" $ do
               el "thead" $ el "tr" $ do


### PR DESCRIPTION
This PR provides range-based filtering over block height in the transfers view. It should be possible to specify a start and end height in the URL for a transfers view of the block explorer.