### PR TITLE
Add links to visit future & past steps of a continuation

### DIFF
--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "chainweb-api",
-  "branch": "master",
+  "branch": "emmanuel/add-search-param-txs-take2",
   "private": false,
-  "rev": "6725d8490fcf43fd5f6b8b0ca731565a58f9c8e6",
-  "sha256": "B3swFmWuEajZ42gpdvHsF2MpWxHU4YiIx/nV+1ZCx30="
+  "rev": "34aa7accb10408dc28fb75694eb10a80eca61099",
+  "sha256": "1m9x9n5mwmv97fkv2z3hvlhlj59xm2mpsc816hzriw28pv1jb9zh"
 }

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "chainweb-api",
-  "branch": "emmanuel/add-search-param-txs-take2",
+  "branch": "master",
   "private": false,
-  "rev": "34aa7accb10408dc28fb75694eb10a80eca61099",
+  "rev": "b3e28d62c622ebda0d84e136ea6c995d5f97e46f",
   "sha256": "1m9x9n5mwmv97fkv2z3hvlhlj59xm2mpsc816hzriw28pv1jb9zh"
 }

--- a/frontend/src/Frontend/ChainwebApi.hs
+++ b/frontend/src/Frontend/ChainwebApi.hs
@@ -475,11 +475,12 @@ searchTxs
     -> Dynamic t (Maybe Limit)
     -> Dynamic t (Maybe Offset)
     -> Dynamic t (QParam Text)
+    -> Dynamic t (QParam Text)
     -> Dynamic t (QParam Int)
     -> Dynamic t (QParam Int)
     -> Event t ()
     -> m (Event t (Either Text (Bool,[TxSummary])))
-searchTxs nc lim off needle minHeight maxHeight evt = do
+searchTxs nc lim off needle pactid minHeight maxHeight evt = do
     case _netConfig_dataHost nc of
       Nothing -> return never
       Just dh -> do
@@ -489,7 +490,7 @@ searchTxs nc lim off needle minHeight maxHeight evt = do
                 (Proxy :: Proxy (LooperTag TxSummary ()))
                 (constDyn $ mkDataUrl dh)
                 nextHeaderOpts
-        txResp <- requestLooper (\limm offf nextToken evt' -> go limm offf needle minHeight maxHeight nextToken evt') lim off evt
+        txResp <- requestLooper (\limm offf nextToken evt' -> go limm offf needle pactid minHeight maxHeight nextToken evt') lim off evt
         return $ handleLooperResults <$> txResp
 
 handleLooperResults :: Either (ReqResult t [result]) (LooperTag result callerTag) -> Either Text (Bool, [result])

--- a/frontend/src/Frontend/Page/Common.hs
+++ b/frontend/src/Frontend/Page/Common.hs
@@ -21,10 +21,12 @@ module Frontend.Page.Common
 
 ------------------------------------------------------------------------------
 import Control.Lens
+import Control.Monad (unless, when)
 ------------------------------------------------------------------------------
 import Data.Aeson as A
 import Data.Foldable
 import Data.Functor (void)
+import Data.List (partition)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as M
 import Data.Maybe
@@ -189,10 +191,43 @@ renderPactExec (PactExec stepCount y x step (PactId pid) pcont rb) netId res =
       tfield "Rollback" $ text $ tshow rb
       tfield "Next Step" $ case res of
         Left err -> tfield "Error" $ text err
-        Right (False,_) -> pure ()
-        Right (True,[]) -> text "No succeeding continuation steps"
-        Right (True,next) -> do
-          txDetailLink $ _txSummary_requestKey $ head next
+        Right (False,_) -> pure () -- TODO: Should be impossible
+        Right (True,[]) -> text "No subsequent continuation steps"
+        Right (True,xs) -> case partition ((== TxSucceeded) . _txSummary_result) xs of
+          ([],[]) -> text "No subsequent continuation steps"
+          ([next],[]) -> txDetailLink $ _txSummary_requestKey next
+          (ys,[]) -> do
+            text "Multiple subsequent continuation steps: "
+            iforM_ ys $ \i next -> do
+              text $ " " <> tshow i <> ": "
+              txDetailLink $ _txSummary_requestKey next
+              when (i < length ys - 1) $ el "br" blank
+          ([next], zs) -> do
+            text "This succeeded: "
+            txDetailLink $ _txSummary_requestKey next
+            el "br" blank
+            text $ "Multiple subsequent failed continuation steps; this many failed: " <> tshow (length zs)
+            el "br" blank
+            iforM_ (take 10 zs) $ \i z -> do
+              text "Failed: "
+              txDetailLink $ _txSummary_requestKey z
+              when (i < length zs - 1) $  el "br" blank
+            when (not $ null $ drop 10 zs) $ text "...and more"
+          (ys,zs) -> do
+            unless (null ys) $ do
+              el "br" $ text "These succeeded: "
+              iforM_ ys $ \i next -> do
+                text $ " " <> tshow i <> ": "
+                txDetailLink $ _txSummary_requestKey next
+                when (i < length ys - 1) $ el "br" blank
+            el "br" blank
+            text $ "Multiple subsequent continuation steps; this many failed: " <> tshow (length zs)
+            el "br" blank
+            iforM_ (take 10 zs) $ \i z -> do
+              text "Failed: "
+              txDetailLink $ _txSummary_requestKey z
+              when (i < length zs - 1) $  el "br" blank
+            when (not $ null $ drop 10 zs) $ text "...and more"
   where
     txDetailLink rk = routeLink (mkTxDetailRoute rk) $ text rk
     mkTxDetailRoute rk = mkNetRoute netId $ NetRoute_TxDetail :/ rk

--- a/frontend/src/Frontend/Page/Common.hs
+++ b/frontend/src/Frontend/Page/Common.hs
@@ -26,7 +26,6 @@ import Control.Monad (unless, when)
 import Data.Aeson as A
 import Data.Foldable
 import Data.Functor (void)
-import Data.List (partition)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as M
 import Data.Maybe
@@ -191,7 +190,7 @@ renderPactExec (PactExec stepCount y x step (PactId pid) pcont rb) netId res =
       tfield "Rollback" $ text $ tshow rb
       tfield "Next Step" $ case res of
         Left err -> tfield "Error" $ text err
-        Right (xs) -> case partition ((== TxSucceeded) . _txSummary_result) xs of
+        Right xs -> case span ((== TxSucceeded) . _txSummary_result) xs of
           (ys,zs) -> do
             unless (null ys) $ do
               text "Successful:"

--- a/frontend/src/Frontend/Page/Common.hs
+++ b/frontend/src/Frontend/Page/Common.hs
@@ -199,6 +199,7 @@ renderPactExec (PactExec stepCount y x step (PactId pid) pcont rb) netId res =
               iforM_ ys $ \i next -> do
                 txDetailLink $ _txSummary_requestKey next
                 when (i < length ys - 1) $ el "br" blank
+            el "br" blank
             unless (null zs) $ do
               text $ "Failed:"
               el "br" blank

--- a/frontend/src/Frontend/Page/Common.hs
+++ b/frontend/src/Frontend/Page/Common.hs
@@ -178,7 +178,7 @@ renderPactExec
     => Prerender js t m
     => PactExec
     -> NetId
-    -> Either Text (Bool,[TxSummary])
+    -> Either Text [TxSummary]
     -> m ()
 renderPactExec (PactExec stepCount y x step (PactId pid) pcont rb) netId res =
     detailsSection $ do
@@ -191,9 +191,7 @@ renderPactExec (PactExec stepCount y x step (PactId pid) pcont rb) netId res =
       tfield "Rollback" $ text $ tshow rb
       tfield "Next Step" $ case res of
         Left err -> tfield "Error" $ text err
-        Right (False,_) -> pure () -- TODO: Should be impossible
-        Right (True,[]) -> text "No subsequent continuation steps"
-        Right (True,xs) -> case partition ((== TxSucceeded) . _txSummary_result) xs of
+        Right xs -> case partition ((== TxSucceeded) . _txSummary_result) xs of
           ([],[]) -> text "No subsequent continuation steps"
           ([next],[]) -> txDetailLink $ _txSummary_requestKey next
           (ys,[]) -> do

--- a/frontend/src/Frontend/Page/Transaction.hs
+++ b/frontend/src/Frontend/Page/Transaction.hs
@@ -70,7 +70,8 @@ transactionPage netId netConfig cid bp hash = do
           Chain_BlockHash :/ (hashB64U hash, Block_Header :/ ())) $ text $ hashB64U hash
 
     let cutText = elAttr "div" ("class" =: "cut-text")
-    let lastMay = foldl (const Just) Nothing
+    let lastMay :: [a] -> Maybe a
+        lastMay = foldl (const Just) Nothing
     pb <- getPostBuild
 
     el "h2" $ text $ "Block Transactions"

--- a/frontend/src/Frontend/Page/TxDetail.hs
+++ b/frontend/src/Frontend/Page/TxDetail.hs
@@ -132,6 +132,10 @@ txDetailPage nc netId cwVer txDetails = do
           tfield "Continuation" $ do
             pb <- getPostBuild
             let cont = _txDetail_continuation $ head txDetails
+            let ditchPartialResult = \case
+                       Left t -> Left t
+                       Right (False,_) -> Left "A partial response is impossible!"
+                       Right (True,r) -> Right r
             forM_ cont $ \c -> do
               res <- searchTxs nc
                  (constDyn Nothing)
@@ -139,7 +143,7 @@ txDetailPage nc netId cwVer txDetails = do
                  (constDyn QNone)
                  (constDyn (QParamSome $ _txDetail_requestKey $ head txDetails))
                  (constDyn QNone) (constDyn QNone) pb
-              widgetHold_ (inlineLoader "Querying continuation info...") (renderCont c <$> res)
+              widgetHold_ (inlineLoader "Querying continuation info...") (renderCont c . ditchPartialResult <$> res)
           tfield "Transaction ID" $ text $ tshow (_txDetail_txid $ head txDetails)
       tfield "Events" $ elClass "table" "ui definition table" $ el "tbody" $
         forM_ (_txDetail_events $ head txDetails) $ \ ev -> el "tr" $ do

--- a/frontend/src/Frontend/Page/TxDetail.hs
+++ b/frontend/src/Frontend/Page/TxDetail.hs
@@ -108,15 +108,15 @@ txDetailPage netId cwVer txDetails = do
               txDetailLink rk = do
                 text "Continuation of "
                 routeLink (mkTxDetailRoute rk) $ text rk
-          case previousSteps of
-            Just steps -> do
-              let l = length steps
-              iforM_ steps $ \i step -> do
-                txDetailLink step
-                unless (i >= l - 1) $ el "br" blank
-              forM_ initialCode $ \c ->
-                elAttr "pre" ("style" =: "white-space: pre-wrap;") $ text c
-            Nothing -> text "No previous steps?"
+          elClass "table" "ui definition table" $ el "tbody" $ do
+            case previousSteps of
+              Just steps -> tfield "Past Steps" $ do
+                let l = length steps
+                iforM_ steps $ \i step -> do
+                  txDetailLink step
+                  unless (i >= l - 1) $ el "br" blank
+              Nothing -> text "No previous steps?"
+            forM_ initialCode $ \c -> tfield "Initial Code" $ elAttr "pre" ("style" =: "white-space: pre-wrap;") $ text c
       tfield "Transaction Output" $ do
         elClass "table" "ui definition table" $ el "tbody" $ do
           tfield "Gas" $ text $ tshow $ (_txDetail_gas $ head txDetails)

--- a/frontend/src/Frontend/Page/TxDetail.hs
+++ b/frontend/src/Frontend/Page/TxDetail.hs
@@ -133,16 +133,13 @@ txDetailPage nc netId cwVer txDetails = do
             pb <- getPostBuild
             let cont = _txDetail_continuation $ head txDetails
             forM_ cont $ \c -> do
-              if determineIfLastStep c
-                then renderCont c (Right (True,[]))
-                else do
-                  res <- searchTxs nc
-                     (constDyn Nothing)
-                     (constDyn Nothing)
-                     (constDyn QNone)
-                     (constDyn (QParamSome $ _txDetail_requestKey $ head txDetails))
-                     (constDyn QNone) (constDyn QNone) pb
-                  widgetHold_ (inlineLoader "Querying continuation info...") (renderCont c <$> res)
+              res <- searchTxs nc
+                 (constDyn Nothing)
+                 (constDyn Nothing)
+                 (constDyn QNone)
+                 (constDyn (QParamSome $ _txDetail_requestKey $ head txDetails))
+                 (constDyn QNone) (constDyn QNone) pb
+              widgetHold_ (inlineLoader "Querying continuation info...") (renderCont c <$> res)
           tfield "Transaction ID" $ text $ tshow (_txDetail_txid $ head txDetails)
       tfield "Events" $ elClass "table" "ui definition table" $ el "tbody" $
         forM_ (_txDetail_events $ head txDetails) $ \ ev -> el "tr" $ do
@@ -188,10 +185,6 @@ txDetailPage nc netId cwVer txDetails = do
       --   forM_ (_transaction_sigs t) $ \s -> do
       --     el "div" $ text $ unSig s
   where
-    determineIfLastStep v = case fromJSON v of
-      Success (PactExec {..}) -> succ _peStep == _peStepCount
-      A.Error _ -> False
-
     renderCont v res = case fromJSON v of
       Success (pe :: PactExec) -> renderPactExec pe netId res
       A.Error e -> text $ T.pack $ "Unable to render continuation" <> e

--- a/frontend/src/Frontend/Transactions.hs
+++ b/frontend/src/Frontend/Transactions.hs
@@ -97,7 +97,7 @@ transactionSearch = do
         res <- searchTxs nc
                  (constDyn $ Just $ Limit itemsPerPage)
                  (Just . Offset . (*itemsPerPage) . pred <$> page)
-                 (QParamSome <$> needle) (constDyn QNone) (constDyn QNone) newSearch
+                 (QParamSome <$> needle) (constDyn QNone) (constDyn QNone) (constDyn QNone) newSearch
 
         divClass "ui pagination menu" $ do
           let setSearchRoute f e = setRoute $


### PR DESCRIPTION
This PR provides links on the transaction detail pages (/txdetail) to step both forward and backward between individual steps of a continuation. At any given step, the user should be able to traverse back to any step before the current AND traverse to the immediate next step (even if it is fails). We also display failed next steps (we stop at 10). This PR completes the work done in both chainweb-data and chainweb-api for supporting this endeavor.