### PR TITLE
Fix integer account balance parsing

### DIFF
--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "b3e28d62c622ebda0d84e136ea6c995d5f97e46f",
-  "sha256": "1m9x9n5mwmv97fkv2z3hvlhlj59xm2mpsc816hzriw28pv1jb9zh"
+  "rev": "c35b5709f562dec211bc02db8f0dac985fb06d56",
+  "sha256": "1f3jf839iav5pimcz2zc1g01sjlw00q6dfhx98q42bspxixp2d8k"
 }


### PR DESCRIPTION
This PR bumps the `chainweb-api` version, bringing in a commit that fixes the `PactNumber` parser for the cases when a `PactDecimal` values get received as integral numbers. See https://github.com/kadena-io/chainweb-api/pull/49.