### PR TITLE
Add Signers and Signatures fields to txdetail view

### DIFF
--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "c35b5709f562dec211bc02db8f0dac985fb06d56",
-  "sha256": "1f3jf839iav5pimcz2zc1g01sjlw00q6dfhx98q42bspxixp2d8k"
+  "rev": "00650534d4b3065342207a732131c88519209177",
+  "sha256": "0lmrk9plhp4x8g1xczs4f8hld9arglvfsvbkcj9xf82sjs3cj3sm"
 }


### PR DESCRIPTION
This PR adds the "Signers" and "Signatures" fields to the `txdetail` view. These new fields display the new `TxDetails` fields of the `chainweb-data` API added by https://github.com/kadena-io/chainweb-data/pull/152 and https://github.com/kadena-io/chainweb-data/pull/153.

We used to have this information in the block transactions view before we redesigned that view to be a table of brief information about each transaction, each row linking to the corresponding `txdetail` page, losing the Signers and Signatures information in the process. This PR recovers these fields for the `block-explorer`.