### PR TITLE
Flakeify block explorer

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build and cache artifacts
       run: |
         sudo sh -c 'echo "extra-experimental-features = recursive-nix" >> /etc/nix/nix.conf'
-        systemctl restart nix-daemon
+        sudo systemctl restart nix-daemon
 
         echo Build the static site
         nix build .#static --log-lines 500 --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,6 +36,8 @@ jobs:
 
     - name: Build and cache artifacts
       run: |
+        sudo sh -c 'echo "extra-experimental-features = recursive-nix" >> /etc/nix/nix.conf'
+        systemctl restart nix-daemon
+
         echo Build the static site
-        nix build .#static --log-lines 500 --show-trace \
-          --extra-experimental-features recursive-nix
+        nix build .#static --log-lines 500 --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,41 @@
+name: Build and cache with Nix
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - '**'
+
+jobs:
+  build-and-cache:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 740
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Nix with caching
+      uses: kadena-io/setup-nix-with-cache/by-root@v3
+      with:
+        cache_url: s3://nixcache.chainweb.com?region=us-east-1
+        signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+
+    - name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ secrets.NIX_CACHE_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.NIX_CACHE_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Give root user AWS credentials
+      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
+
+    - name: Build and cache artifacts
+      run: |
+        echo Build the static site
+        nix build .#static --log-lines 500 --show-trace \
+          --extra-experimental-features recursive-nix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693553268,
+        "narHash": "sha256-WLeTs7XzqRKCR8kAkiMAHJG0Ftvn2fsAMCPvkZ9oWAk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0edab9b485884d6e287e76f303f4201992ea3ff5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
     };
     forAllSystems = f:
       nixpkgs.lib.genAttrs [
-        "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aaarch64-darwin"
+        "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"
       ] (system: f nixpkgs.legacyPackages.${system});
   in {
     defaultPackage = forAllSystems (pkgs: pkgs.runCommand "block-explorer"

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
       filter = path: type:
         baseNameOf path != "flake.nix" &&
         baseNameOf path != "flake.lock" &&
-        baseNameOf path != "flake";
+        baseNameOf path != "flake" &&
+        baseNameOf path != ".github"
+      ;
     };
     publicDataBackends = {
       mainnet01 = {

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,8 @@
       }: pkgs.runCommand "block-explorer-static" { buildInputs = [ pkgs.coreutils ]; } ''
         mkdir $out
         ln -s ${self.packages.x86_64-linux.static}/* $out
-        ROUTE=$(base64 <<< ${route})
-        DATA_BACKENDS=$(base64 <<< ${builtins.toJSON dataBackends})
+        ROUTE=$(base64 -w 0 <<< ${route})
+        DATA_BACKENDS=$(base64 -w 0 <<< ${builtins.toJSON dataBackends})
         ${pkgs.mustache-go}/bin/mustache $out/index.html.mustache > $out/index.html <<EOF
           {
             "route": "$ROUTE",

--- a/flake.nix
+++ b/flake.nix
@@ -104,9 +104,7 @@
             exec ${pkgs.caddy}/bin/caddy run \
               --config <(${pkgs.caddy}/bin/caddy adapt --config ${pkgs.writeText "Caddyfile" ''
                 http://:8000 {
-                    # Redirect from root to /
-                    @root path /
-                    redir @root /
+                    redir / /mainnet
 
                     root * ${default}
                     file_server

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
     };
     forAllSystems = f:
       nixpkgs.lib.genAttrs [
-        "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"
+        "x86_64-linux" "x86_64-darwin" "aarch64-linux"
       ] (system: f nixpkgs.legacyPackages.${system});
   in {
     defaultPackage = forAllSystems (pkgs: pkgs.runCommand "block-explorer"

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
   };
   outputs = { self, nixpkgs }: let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
     obelisk = builtins.fetchTarball {
       url = "https://github.com/obsidiansystems/obelisk/archive/7ad33cbe3e84b209e83c505ce25486445bbd602e.tar.gz";
       sha256 = "sha256:0dlk8y6rxc87crw7764zq2py7nqn38lw496ca1y893m9gdq8qdkz";
@@ -45,9 +43,12 @@
       url = "https://github.com/kadena-io/pact/archive/d4452cbf7cbf589be294ec0980bd44e97edb4729.tar.gz";
       sha256 = "sha256:0qk8hfpgcwg6s6ny71hnk1w4pwlrcy4bbba2riwmiiha7bapj3n2";
     };
-
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aaarch64-darwin"
+      ] (system: f nixpkgs.legacyPackages.${system});
   in {
-    defaultPackage.${system} = pkgs.runCommand "block-explorer"
+    defaultPackage = forAllSystems (pkgs: pkgs.runCommand "block-explorer"
       {
         buildInputs = [ pkgs.nix ];
         NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
@@ -69,6 +70,6 @@
         OUT=$(nix-build ${self} -A exe)
         ln -s $OUT $out
       ''
-      ;
+    );
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
     packages = forAllSystems ({pkgs, system, ...}:
       pkgs.lib.optionalAttrs (system == "x86_64-linux") x86-linux-only-packages // rec {
         default = renderStatic { inherit pkgs; };
-        servePublic = pkgs.writeShellScriptBin "block-explorer-serve-default"
+        serve = pkgs.writeShellScriptBin "block-explorer-serve-default"
           ''
             exec ${pkgs.caddy}/bin/caddy run \
               --config <(${pkgs.caddy}/bin/caddy adapt --config ${pkgs.writeText "Caddyfile" ''

--- a/flake.nix
+++ b/flake.nix
@@ -45,31 +45,96 @@
     };
     forAllSystems = f:
       nixpkgs.lib.genAttrs [
-        "x86_64-linux" "x86_64-darwin" "aarch64-linux"
+        "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"
       ] (system: f nixpkgs.legacyPackages.${system});
+    selfWithoutFlake = builtins.path {
+      name = "block-explorer-without-flake";
+      path = ./.;
+      filter = path: type:
+        baseNameOf path != "flake.nix" &&
+        baseNameOf path != "flake.lock" &&
+        baseNameOf path != "flake";
+    };
   in {
-    defaultPackage = forAllSystems (pkgs: pkgs.runCommand "block-explorer"
-      {
-        buildInputs = [ pkgs.nix ];
-        NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
-        evalTimeDependencies = ''
-          ${obelisk}
-          ${kpkgs}
-          ${reflex-platform}
-          ${nixpkgs_1}
-          ${gitignore}
-          ${reflex-dom}
-          ${reflex-frp}
-          ${nix-thunk}
-          ${chainweb-api}
-          ${pact}
-        '';
-        requiredSystemFeatures = [ "recursive-nix" ];
-      }
-      ''
-        OUT=$(nix-build ${self} -A exe)
-        ln -s $OUT $out
-      ''
-    );
+    inherit selfWithoutFlake;
+    packages.x86_64-linux = let
+        pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      in rec {
+        exe = pkgs.runCommand "block-explorer" {
+            buildInputs = [ pkgs.nix ];
+            NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
+            evalTimeDependencies = ''
+              ${obelisk}
+              ${kpkgs}
+              ${reflex-platform}
+              ${nixpkgs_1}
+              ${gitignore}
+              ${reflex-dom}
+              ${reflex-frp}
+              ${nix-thunk}
+              ${chainweb-api}
+              ${pact}
+            '';
+            requiredSystemFeatures = [ "recursive-nix" ];
+          }
+          ''
+            OUT=$(nix-build ${selfWithoutFlake} -A exe)
+            ln -s $OUT $out
+          '';
+        static = pkgs.runCommand "block-explorer-static"
+          { buildInputs = [ pkgs.coreutils pkgs.curl pkgs.bash ];
+          }
+          ''
+            mkdir -p config/common config/frontend
+            cat - > config/common/route <<EOF
+              http://localhost:8000
+            EOF
+            ROUTE64=$(base64 config/common/route)
+            cat - > config/frontend/data-backends <<EOF
+              {
+                "mainnet01": {
+                  "p2p": "https://estats.chainweb.com:443",
+                  "service": "https://estats.chainweb.com:443",
+                  "data": "https://estats.chainweb.com:443"
+                },
+                "testnet04": {
+                  "p2p": "https://estats.testnet.chainweb.com:443",
+                  "service": "https://estats.testnet.chainweb.com:443",
+                  "data": "https://estats.testnet.chainweb.com:443"
+                }
+              }
+            EOF
+            DATA_BACKENDS64=$(base64 config/frontend/data-backends)
+            ${exe}/backend &
+            sleep 1
+            curl -s -o index.html http://0.0.0.0:8000
+            mkdir -p $out
+            # We'll convert index.html into a mustache template in which ROUTE64
+            # is replaced with {{route}} and DATA_BACKENDS64 is replaced with {{dataBackends}}
+            # sed -e "s|$ROUTE64|{{route}}|g" \
+            #     -e "s|$DATA_BACKENDS64|{{dataBackends}}|g" \
+            #     index.html > $out/index.html.mustache
+            cp index.html $out/index.html
+
+            bash ${flake/copy-assets.sh} ${exe}/frontend.jsexe.assets $out/ghcjs
+            bash ${flake/copy-assets.sh} ${exe}/static.assets $out/static
+            cp ${exe}/version $out/version
+          '';
+        serveDefault = pkgs.writeShellScriptBin "block-explorer-serve-default"
+          ''
+            exec ${pkgs.caddy}/bin/caddy run \
+              --config <(${pkgs.caddy}/bin/caddy adapt --config ${pkgs.writeText "Caddyfile" ''
+                http://:8000 {
+                    # Redirect from root to /
+                    @root path /
+                    redir @root /
+
+                    root * ${static}
+                    file_server
+                    try_files {path} {path}/ /index.html
+                }
+            ''})
+          '';
+      };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,46 +3,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
   };
   outputs = { self, nixpkgs }: let
-    obelisk = builtins.fetchTarball {
-      url = "https://github.com/obsidiansystems/obelisk/archive/7ad33cbe3e84b209e83c505ce25486445bbd602e.tar.gz";
-      sha256 = "sha256:0dlk8y6rxc87crw7764zq2py7nqn38lw496ca1y893m9gdq8qdkz";
-    };
-    kpkgs = builtins.fetchTarball {
-      url = "https://github.com/kadena-io/kpkgs/archive/a71c4263c0f1f53935d4ed9b642a672074445494.tar.gz";
-      sha256 = "sha256:1mccc2bl9k2a15fkj7jg48g2lmw2zwwbxwiapl6aklkvs4j7qinb";
-    };
-    reflex-platform = builtins.fetchTarball {
-      url = "https://github.com/reflex-frp/reflex-platform/archive/efc6d923c633207d18bd4d8cae3e20110a377864.tar.gz";
-      sha256 = "sha256:121rmnkx8nwiy96ipfyyv6vrgysv0zpr2br46y70zf4d0y1h1lz5";
-    };
-    nixpkgs_1 = builtins.fetchTarball {
-      url = "https://github.com/obsidiansystems/nixpkgs/archive/a5cc7b77c090ede3ac380962ea876b83d847592c.tar.gz";
-      sha256 = "sha256:0mfrfrgkc8bfc3hcnbzqmab021i3w27mczak99ab4ca154ml297i";
-    };
-    gitignore = builtins.fetchTarball {
-      url = "https://github.com/hercules-ci/gitignore.nix/archive/7415c4feb127845553943a3856cbc5cb967ee5e0.tar.gz";
-      sha256 = "sha256:1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i";
-    };
-    reflex-dom = builtins.fetchTarball {
-      url = "https://github.com/reflex-frp/reflex-dom/archive/02c61ecff6ed6e1bda4a68b24d6c2e04c70a31e2.tar.gz";
-      sha256 = "sha256:1m54blk368n5ljj1iyicas2ksl1f0x7i5gkqpy1l6yjq3f8r9awy";
-    };
-    reflex-frp = builtins.fetchTarball {
-      url = "https://github.com/reflex-frp/reflex/archive/3369fceadb132a980ab1ccbed7471ba36a9ef642.tar.gz";
-      sha256 = "sha256:0wy41ya0g6klw7ps8ki2cqb9mm1y4d21jm98dd5niahbdldzkhl2";
-    };
-    nix-thunk = builtins.fetchTarball {
-      url = "https://github.com/obsidiansystems/nix-thunk/archive/bab7329163fce579eaa9cfba67a4851ab806b76f.tar.gz";
-      sha256 = "sha256:0wn96xn6prjzcsh4n8p1n40wi8la53ym5h2frlqbfzas7isxwygg";
-    };
-    chainweb-api = builtins.fetchTarball {
-      url = "https://github.com/kadena-io/chainweb-api/archive/00650534d4b3065342207a732131c88519209177.tar.gz";
-      sha256 = "sha256:0lmrk9plhp4x8g1xczs4f8hld9arglvfsvbkcj9xf82sjs3cj3sm";
-    };
-    pact = builtins.fetchTarball {
-      url = "https://github.com/kadena-io/pact/archive/d4452cbf7cbf589be294ec0980bd44e97edb4729.tar.gz";
-      sha256 = "sha256:0qk8hfpgcwg6s6ny71hnk1w4pwlrcy4bbba2riwmiiha7bapj3n2";
-    };
     forAllSystems = f:
       nixpkgs.lib.genAttrs [
         "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"
@@ -63,18 +23,7 @@
         exe = pkgs.runCommand "block-explorer" {
             buildInputs = [ pkgs.nix ];
             NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
-            evalTimeDependencies = ''
-              ${obelisk}
-              ${kpkgs}
-              ${reflex-platform}
-              ${nixpkgs_1}
-              ${gitignore}
-              ${reflex-dom}
-              ${reflex-frp}
-              ${nix-thunk}
-              ${chainweb-api}
-              ${pact}
-            '';
+            evalTimeDependencies = import flake/evalTimeDependencies.nix;
             requiredSystemFeatures = [ "recursive-nix" ];
           }
           ''

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,11 @@
                 http://:8000 {
                     redir / /mainnet
 
+                    @notGhcjsOrStatic not path /ghcjs/* /static/*
+                    header @notGhcjsOrStatic Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0"
+                    header @notGhcjsOrStatic Pragma "no-cache"
+                    header @notGhcjsOrStatic Expires "0"
+
                     root * ${default}
                     file_server
                     try_files {path} {path}/ /index.html

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+    obelisk = builtins.fetchTarball {
+      url = "https://github.com/obsidiansystems/obelisk/archive/7ad33cbe3e84b209e83c505ce25486445bbd602e.tar.gz";
+      sha256 = "sha256:0dlk8y6rxc87crw7764zq2py7nqn38lw496ca1y893m9gdq8qdkz";
+    };
+    kpkgs = builtins.fetchTarball {
+      url = "https://github.com/kadena-io/kpkgs/archive/a71c4263c0f1f53935d4ed9b642a672074445494.tar.gz";
+      sha256 = "sha256:1mccc2bl9k2a15fkj7jg48g2lmw2zwwbxwiapl6aklkvs4j7qinb";
+    };
+    reflex-platform = builtins.fetchTarball {
+      url = "https://github.com/reflex-frp/reflex-platform/archive/efc6d923c633207d18bd4d8cae3e20110a377864.tar.gz";
+      sha256 = "sha256:121rmnkx8nwiy96ipfyyv6vrgysv0zpr2br46y70zf4d0y1h1lz5";
+    };
+    nixpkgs_1 = builtins.fetchTarball {
+      url = "https://github.com/obsidiansystems/nixpkgs/archive/a5cc7b77c090ede3ac380962ea876b83d847592c.tar.gz";
+      sha256 = "sha256:0mfrfrgkc8bfc3hcnbzqmab021i3w27mczak99ab4ca154ml297i";
+    };
+    gitignore = builtins.fetchTarball {
+      url = "https://github.com/hercules-ci/gitignore.nix/archive/7415c4feb127845553943a3856cbc5cb967ee5e0.tar.gz";
+      sha256 = "sha256:1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i";
+    };
+    reflex-dom = builtins.fetchTarball {
+      url = "https://github.com/reflex-frp/reflex-dom/archive/02c61ecff6ed6e1bda4a68b24d6c2e04c70a31e2.tar.gz";
+      sha256 = "sha256:1m54blk368n5ljj1iyicas2ksl1f0x7i5gkqpy1l6yjq3f8r9awy";
+    };
+    reflex-frp = builtins.fetchTarball {
+      url = "https://github.com/reflex-frp/reflex/archive/3369fceadb132a980ab1ccbed7471ba36a9ef642.tar.gz";
+      sha256 = "sha256:0wy41ya0g6klw7ps8ki2cqb9mm1y4d21jm98dd5niahbdldzkhl2";
+    };
+    nix-thunk = builtins.fetchTarball {
+      url = "https://github.com/obsidiansystems/nix-thunk/archive/bab7329163fce579eaa9cfba67a4851ab806b76f.tar.gz";
+      sha256 = "sha256:0wn96xn6prjzcsh4n8p1n40wi8la53ym5h2frlqbfzas7isxwygg";
+    };
+    chainweb-api = builtins.fetchTarball {
+      url = "https://github.com/kadena-io/chainweb-api/archive/00650534d4b3065342207a732131c88519209177.tar.gz";
+      sha256 = "sha256:0lmrk9plhp4x8g1xczs4f8hld9arglvfsvbkcj9xf82sjs3cj3sm";
+    };
+    pact = builtins.fetchTarball {
+      url = "https://github.com/kadena-io/pact/archive/d4452cbf7cbf589be294ec0980bd44e97edb4729.tar.gz";
+      sha256 = "sha256:0qk8hfpgcwg6s6ny71hnk1w4pwlrcy4bbba2riwmiiha7bapj3n2";
+    };
+
+  in {
+    defaultPackage.${system} = pkgs.runCommand "block-explorer"
+      {
+        buildInputs = [ pkgs.nix ];
+        NIX_PATH = "nixpkgs=${nixpkgs.outPath}";
+        evalTimeDependencies = ''
+          ${obelisk}
+          ${kpkgs}
+          ${reflex-platform}
+          ${nixpkgs_1}
+          ${gitignore}
+          ${reflex-dom}
+          ${reflex-frp}
+          ${nix-thunk}
+          ${chainweb-api}
+          ${pact}
+        '';
+        requiredSystemFeatures = [ "recursive-nix" ];
+      }
+      ''
+        OUT=$(nix-build ${self} -A exe)
+        ln -s $OUT $out
+      ''
+      ;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -84,8 +84,13 @@
                 -e "s|$DATA_BACKENDS64|{{dataBackends}}|g" \
                 index.html > $out/index.html.mustache
 
-            bash ${flake/copy-assets.sh} ${exe}/frontend.jsexe.assets $out/ghcjs
-            bash ${flake/copy-assets.sh} ${exe}/static.assets $out/static
+            bash ${flake/copy-assets.sh} ${exe}/frontend.jsexe.assets ghcjs
+            find ghcjs \( -name "*.unminified.js" -o -name "*.js.map" \) -exec rm -f {} +
+            cp -Lr ghcjs $out/ghcjs
+
+            bash ${flake/copy-assets.sh} ${exe}/static.assets static
+            cp -Lr static $out/static
+
             cp ${exe}/version $out/version
           '';
       };

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
     packages = forAllSystems ({pkgs, system, ...}:
       pkgs.lib.optionalAttrs (system == "x86_64-linux") x86-linux-only-packages // rec {
         default = renderStatic { inherit pkgs; };
-        serve = pkgs.writeShellScriptBin "block-explorer-serve-default"
+        serve = pkgs.writeShellScriptBin "serve-block-explorer"
           ''
             exec ${pkgs.caddy}/bin/caddy run \
               --config <(${pkgs.caddy}/bin/caddy adapt --config ${pkgs.writeText "Caddyfile" ''
@@ -113,5 +113,11 @@
             ''})
           '';
       });
+    apps = forAllSystems ({pkgs, system, ...}: {
+      default = {
+        type = "app";
+        program = "${self.packages.${system}.serve}/bin/serve-block-explorer";
+      };
+    });
   };
 }

--- a/flake/copy-assets.sh
+++ b/flake/copy-assets.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -e
 
 # Source directory
 src="$1"

--- a/flake/copy-assets.sh
+++ b/flake/copy-assets.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Source directory
+src="$1"
+# Destination directory
+dst="$2"
+
+# Ensure destination exists
+mkdir -p "$dst"
+
+# Recursive function to handle and process the symlinks and directories
+process_dir() {
+    local current_src="$1"
+    local current_dst="$2"
+
+    for item in "$current_src"/*; do
+
+        local relpath=${item#$src}
+        local target="$current_dst/$relpath"
+
+        # Handle type 1 links (with "target" files)
+        if [[ -e "$item/target" ]]; then
+            local tgt_path=$(cat "$item/target")
+            ln -sf "$tgt_path" "$target"
+
+        # Handle type 2 links (with "encodings/identity" files)
+        elif [[ -e "$item/encodings/identity" ]]; then
+            local identity_path=$(readlink -f "$item/encodings/identity")
+            ln -sf "$identity_path" "$target"
+
+        elif [[ -d "$item" ]]; then
+          local relpath=${item#$src}
+          local target_dir="$current_dst/$relpath"
+          mkdir -p "$target_dir"
+
+          # Recurse into this directory
+          process_dir "$item" "$current_dst"
+        fi
+
+    done
+}
+
+# Start processing from the source directory
+process_dir "$src" "$dst"
+
+echo "Done!"

--- a/flake/evalTimeDependencies.nix
+++ b/flake/evalTimeDependencies.nix
@@ -1,0 +1,53 @@
+let
+  obelisk = builtins.fetchTarball {
+    url = "https://github.com/obsidiansystems/obelisk/archive/7ad33cbe3e84b209e83c505ce25486445bbd602e.tar.gz";
+    sha256 = "sha256:0dlk8y6rxc87crw7764zq2py7nqn38lw496ca1y893m9gdq8qdkz";
+  };
+  kpkgs = builtins.fetchTarball {
+    url = "https://github.com/kadena-io/kpkgs/archive/a71c4263c0f1f53935d4ed9b642a672074445494.tar.gz";
+    sha256 = "sha256:1mccc2bl9k2a15fkj7jg48g2lmw2zwwbxwiapl6aklkvs4j7qinb";
+  };
+  reflex-platform = builtins.fetchTarball {
+    url = "https://github.com/reflex-frp/reflex-platform/archive/efc6d923c633207d18bd4d8cae3e20110a377864.tar.gz";
+    sha256 = "sha256:121rmnkx8nwiy96ipfyyv6vrgysv0zpr2br46y70zf4d0y1h1lz5";
+  };
+  nixpkgs_1 = builtins.fetchTarball {
+    url = "https://github.com/obsidiansystems/nixpkgs/archive/a5cc7b77c090ede3ac380962ea876b83d847592c.tar.gz";
+    sha256 = "sha256:0mfrfrgkc8bfc3hcnbzqmab021i3w27mczak99ab4ca154ml297i";
+  };
+  gitignore = builtins.fetchTarball {
+    url = "https://github.com/hercules-ci/gitignore.nix/archive/7415c4feb127845553943a3856cbc5cb967ee5e0.tar.gz";
+    sha256 = "sha256:1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i";
+  };
+  reflex-dom = builtins.fetchTarball {
+    url = "https://github.com/reflex-frp/reflex-dom/archive/02c61ecff6ed6e1bda4a68b24d6c2e04c70a31e2.tar.gz";
+    sha256 = "sha256:1m54blk368n5ljj1iyicas2ksl1f0x7i5gkqpy1l6yjq3f8r9awy";
+  };
+  reflex-frp = builtins.fetchTarball {
+    url = "https://github.com/reflex-frp/reflex/archive/3369fceadb132a980ab1ccbed7471ba36a9ef642.tar.gz";
+    sha256 = "sha256:0wy41ya0g6klw7ps8ki2cqb9mm1y4d21jm98dd5niahbdldzkhl2";
+  };
+  nix-thunk = builtins.fetchTarball {
+    url = "https://github.com/obsidiansystems/nix-thunk/archive/bab7329163fce579eaa9cfba67a4851ab806b76f.tar.gz";
+    sha256 = "sha256:0wn96xn6prjzcsh4n8p1n40wi8la53ym5h2frlqbfzas7isxwygg";
+  };
+  chainweb-api = builtins.fetchTarball {
+    url = "https://github.com/kadena-io/chainweb-api/archive/00650534d4b3065342207a732131c88519209177.tar.gz";
+    sha256 = "sha256:0lmrk9plhp4x8g1xczs4f8hld9arglvfsvbkcj9xf82sjs3cj3sm";
+  };
+  pact = builtins.fetchTarball {
+    url = "https://github.com/kadena-io/pact/archive/d4452cbf7cbf589be294ec0980bd44e97edb4729.tar.gz";
+    sha256 = "sha256:0qk8hfpgcwg6s6ny71hnk1w4pwlrcy4bbba2riwmiiha7bapj3n2";
+  };
+in [
+  obelisk
+  kpkgs
+  reflex-platform
+  nixpkgs_1
+  gitignore
+  reflex-dom
+  reflex-frp
+  nix-thunk
+  chainweb-api
+  pact
+]


### PR DESCRIPTION
This PR adds a `flake.nix` layer around the legacy `default.nix` build setup for the `block-explorer`.

`block-explorer` relies on the excellent `obelisk` infrastructure for building the backend and the frontend. The version of `obelisk` depended on by `block-explorer` (and I believe latest version too) is not compatible with being imported into a flake out of the box. The reason is that `obelisk` (and its transitive dependencies) does impure things like looking up `builtins.currentSystem` and `import <nixpkgs>`, which won't work under flakes' pure evaluation. You can of course still include it in a flake and build the flake (and any downstream flake that depends on it) with `--impure`, but there are still 2 problems:
* `--impure` means that the resulting store hash depends on the environment in which the package is building, so you may get spurious cache misses
* The full Nix evaluation of `block-explorer` takes a non-trivial amount of time, and any downstream consumer of `block-explorer` will suffer from this additional evaluation time for every Nix action.
 
This PR addresses all of these issues by wrapping `default.nix` in a `recursive-nix` derivation, that makes the `nix-build -A exe` call as part of the build of its `defaultPackage`. This allows us to recover purity by sandboxing the environment in which Nix evaluation is taking place, so downstream consumers don't need `--impure`. Additionally, since all complex Nix evaluation is happening during the build of the `recursive-nix` derivation, evaluating the flake's `defaultPackage` is almost instantaneous (for any downstream consumer) and as long as the result is in the Nix store or is available in a binary cache, the whole build will be very fast. As long as there's a cache hit, downstream consumers won't even have to fetch any of the Nix dependencies of `block-explorer`.

One caveat with this wrapping is that, since it uses `recursive-nix`, any downstream consumer of this flake will need to enable `--extra-experimental-features recursive-nix` while building this flake, *but only if the result isn't found in a cache*. As long as the cache lookup succeeds, there's essentially no complication whatsoever.

One thing to note with the implementation of this PR is that I had to prepare [a long (and duplicate) list of nix tarballs](https://github.com/kadena-io/block-explorer/compare/enis/flakeify-block-explorer?expand=1#diff-370fdbf69abec4915ebf14c0bb9cfa0f38218732e223b018b2f244b49a2173fa) as [explicit dependencies of the `recursive-nix` derivation](https://github.com/kadena-io/block-explorer/pull/80/commits/830fd4ac6c2e8e0a538330b7863b47dddca2e5dc#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R26). This was necessary, because `recursive-nix` derivations (like every sandboxed Nix derivation) don't have access to the internet, so they can't fetch those packages at Nix evaluation time (of the nested `nix-build` call). By making them explicit build dependencies of the `recursive-nix` derivation, we're making sure that at `nix-build` time they're already available. One interesting thing to note is that it's **OK** for the nested `nix-build` to need to fetch nix store paths from binary caches or access existing `/nix/store` paths on the local machine during its own **build time**, that's because of the way `recursive-nix` coordinates the actual build of any `.drv` generated during the recursive `nix-build`. The trouble is only with anything that needs to be fetched during the nested nix evaluation time.

This PR also post-processes the obelisk output to convert the result into a static SPA. This allows us to run the `block-explorer` on all platforms, even though the nix derivation only builds on `x86_64-linux`. Other platforms reuse the output produced by an `x86_64-linux`, which means they won't be able to build it themselves, but they will happily fetch it from a binary cache. The following shell command can be used to serve this SPA:
```
nix run github:kadena-io/block-explorer
```