### PR TITLE
Add (fast-)development network support (DONT MERGE)

### DIFF
--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -138,13 +138,16 @@ netRouteEncoder = pathComponentEncoder $ \case
   NetRoute_TransferSearch -> PathSegment "transfer" accountParamsEncoder
 
 data FrontendRoute :: * -> * where
-  FR_Main :: FrontendRoute ()
-  FR_About :: FrontendRoute ()
-  FR_Mainnet :: FrontendRoute (R NetRoute)
-  FR_Testnet :: FrontendRoute (R NetRoute)
-  FR_Development :: FrontendRoute (R NetRoute)
-  FR_FastDevelopment :: FrontendRoute (R NetRoute)
-  FR_Customnet :: FrontendRoute (NetConfig, R NetRoute)
+  FR_Prefix :: FrontendRoute (R FrontendRoute')
+
+data FrontendRoute' :: * -> * where
+  FR_Main :: FrontendRoute' ()
+  FR_About :: FrontendRoute' ()
+  FR_Mainnet :: FrontendRoute' (R NetRoute)
+  FR_Testnet :: FrontendRoute' (R NetRoute)
+  FR_Development :: FrontendRoute' (R NetRoute)
+  FR_FastDevelopment :: FrontendRoute' (R NetRoute)
+  FR_Customnet :: FrontendRoute' (NetConfig, R NetRoute)
   -- This type is used to define frontend routes, i.e. ones for which the backend will serve the frontend.
 
 backendRouteEncoder
@@ -154,21 +157,22 @@ backendRouteEncoder = handleEncoder (const (FullRoute_Backend BackendRoute_Missi
     FullRoute_Backend backendRoute -> case backendRoute of
       BackendRoute_Missing -> PathSegment "missing" $ unitEncoder mempty
     FullRoute_Frontend obeliskRoute -> obeliskRouteSegment obeliskRoute $ \case
-      -- The encoder given to PathEnd determines how to parse query parameters,
-      -- in this example, we have none, so we insist on it.
-      FR_Main -> PathEnd $ unitEncoder mempty
-      FR_About -> PathSegment "about" $ unitEncoder mempty
-      FR_Mainnet -> PathSegment "mainnet" netRouteEncoder
-      FR_Testnet -> PathSegment "testnet" netRouteEncoder
-      FR_Development -> PathSegment "development" netRouteEncoder
-      FR_FastDevelopment -> PathSegment "fast-development" netRouteEncoder
-      FR_Customnet -> PathSegment "custom" $ pathParamEncoder netconfigEncoder netRouteEncoder
+      FR_Prefix -> PathSegment "explorer" $ pathComponentEncoder $ \case
+        -- The encoder given to PathEnd determines how to parse query parameters,
+        -- in this example, we have none, so we insist on it.
+        FR_Main -> PathEnd $ unitEncoder mempty
+        FR_About -> PathSegment "about" $ unitEncoder mempty
+        FR_Mainnet -> PathSegment "mainnet" netRouteEncoder
+        FR_Testnet -> PathSegment "testnet" netRouteEncoder
+        FR_Development -> PathSegment "development" netRouteEncoder
+        FR_FastDevelopment -> PathSegment "fast-development" netRouteEncoder
+        FR_Customnet -> PathSegment "custom" $ pathParamEncoder netconfigEncoder netRouteEncoder
 
 netconfigEncoder :: Encoder (Either Text) (Either Text) NetConfig Text
 netconfigEncoder = reviewEncoder (prism' netConfigToRouteText netConfigFromRouteText)
 
 addNetRoute :: NetId -> Int -> R ChainRoute -> R FrontendRoute
-addNetRoute netId c r = case netId of
+addNetRoute netId c r = FR_Prefix :/ case netId of
   NetId_Mainnet -> FR_Mainnet :/ NetRoute_Chain :/ (c, r)
   NetId_Testnet -> FR_Testnet :/ NetRoute_Chain :/ (c, r)
   NetId_Development -> FR_Development :/ NetRoute_Chain :/ (c, r)
@@ -176,7 +180,7 @@ addNetRoute netId c r = case netId of
   NetId_Custom host -> FR_Customnet :/ (host, (NetRoute_Chain :/ (c, r)))
 
 mkNetRoute :: NetId -> DSum NetRoute Identity -> R FrontendRoute
-mkNetRoute netId r = case netId of
+mkNetRoute netId r = FR_Prefix :/ case netId of
     NetId_Mainnet -> FR_Mainnet :/ r
     NetId_Testnet -> FR_Testnet :/ r
     NetId_Development -> FR_Development :/ r
@@ -186,6 +190,7 @@ mkNetRoute netId r = case netId of
 concat <$> mapM deriveRouteComponent
   [ ''BackendRoute
   , ''FrontendRoute
+  , ''FrontendRoute'
   , ''BlockRoute
   , ''ChainRoute
   , ''NetRoute
@@ -199,11 +204,11 @@ getAppRoute = do
       Just r -> return $ T.dropWhileEnd (== '/') $ T.strip $ decodeUtf8 r
 
 -- | Provide a human-readable name for a given section
-tabTitle :: DomBuilder t m => Some FrontendRoute -> m ()
+tabTitle :: DomBuilder t m => Some FrontendRoute' -> m ()
 tabTitle = text . frToText
 
 -- | Provide a human-readable name for a given section
-frToText :: Some FrontendRoute -> Text
+frToText :: Some FrontendRoute' -> Text
 frToText (Some.Some sec) = case sec of
   FR_Main -> "Home"
   FR_About -> "About"

--- a/common/src/Common/Types.hs
+++ b/common/src/Common/Types.hs
@@ -111,6 +111,8 @@ defaultDataBackends :: DataBackends
 defaultDataBackends = DataBackends $ M.fromList
   [ ("mainnet01", netHost NetId_Mainnet)
   , ("testnet04", netHost NetId_Testnet)
+  , ("development", netHost NetId_Development)
+  , ("fast-development", netHost NetId_FastDevelopment)
   ]
 
 
@@ -128,6 +130,8 @@ instance FromJSON ChainwebHost
 data NetId
    = NetId_Mainnet
    | NetId_Testnet
+   | NetId_Development
+   | NetId_FastDevelopment
    | NetId_Custom NetConfig
    deriving (Eq,Ord)
 
@@ -135,6 +139,8 @@ netIdPathSegment :: NetId -> Text
 netIdPathSegment = \case
   NetId_Mainnet -> "mainnet"
   NetId_Testnet -> "testnet"
+  NetId_Development -> "development"
+  NetId_FastDevelopment -> "fast-development"
   NetId_Custom _ -> "custom"
 
 --getNetConfig :: NetId -> AppConfig -> NetConfig
@@ -145,6 +151,8 @@ netIdPathSegment = \case
 netHost :: NetId -> NetConfig
 netHost NetId_Mainnet    = let h = Host "https" "estats.chainweb.com" 443 in NetConfig h h (Just h)
 netHost NetId_Testnet    = let h = Host "https" "api.testnet.chainweb.com" 443 in NetConfig h h Nothing
+netHost NetId_Development     = let h = Host "http" "localhost" 8080 in NetConfig h h (Just h)
+netHost NetId_FastDevelopment = let h = Host "http" "localhost" 8080 in NetConfig h h Nothing
 netHost (NetId_Custom nc) = nc
 
 humanReadableTextPrism :: (Humanizable a, Readable a) => Prism Text Text a a

--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,21 @@
         baseNameOf path != ".github"
       ;
     };
-    publicDataBackends = {
-      mainnet01 = {
-        p2p = "https://estats.chainweb.com:443";
-        service = "https://estats.chainweb.com:443";
-        data = "https://estats.chainweb.com:443";
+    publicDataBackends = let
+      estats = "https://estats.chainweb.com:443";
+      estats-testnet = "https://estats.testnet.chainweb.com:443";
+      devnet = "http://localhost:8080";
+      constNetConfig = url: {
+        p2p = url;
+        service = url;
+        data = url;
       };
-      testnet04 = {
-        p2p = "https://estats.testnet.chainweb.com:443";
-        service = "https://estats.testnet.chainweb.com:443";
-        data = "https://estats.testnet.chainweb.com:443";
+      in {
+        mainnet01 = constNetConfig estats;
+        testnet04 = constNetConfig estats-testnet;
+        development = constNetConfig devnet;
+        fast-development = constNetConfig devnet;
       };
-    };
     renderStatic = {
         pkgs,
         route ? "http://localhost:8000",

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
             ${exe}/backend &
             sleep 1
 
-            curl -s -o index.html http://0.0.0.0:8000/explorer/about
+            curl -s -o index.html http://0.0.0.0:8000/about
 
             mkdir -p $out
             # We'll convert index.html into a mustache template in which ROUTE64

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
             ${exe}/backend &
             sleep 1
 
-            curl -s -o index.html http://0.0.0.0:8000
+            curl -s -o index.html http://0.0.0.0:8000/explorer/about
 
             mkdir -p $out
             # We'll convert index.html into a mustache template in which ROUTE64

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -89,7 +89,7 @@ mainDispatch route ndbs = do
     FR_Prefix -> subRoute_ $ \case
       FR_Main -> setRoute ((FR_Prefix :/ FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
       FR_About -> prerender_ blank $ do
-        divClass "ui fixed inverted menu" $ nav NetId_Mainnet
+        divClass "ui fixed inverted menu" $ nav NetId_FastDevelopment
         aboutWidget
       FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet
       FR_Testnet -> networkDispatch route ndbs NetId_Testnet

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PackageImports             #-}
 {-# LANGUAGE RecursiveDo                #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TupleSections              #-}
@@ -42,9 +43,9 @@ import           Reflex.Dom.Core hiding (Value)
 import           Reflex.Dom.EventSource
 import           Reflex.Network
 import           Text.Printf
-import qualified JSDOM as DOM
-import qualified JSDOM.EventM as DOM
-import qualified JSDOM.Generated.Document as DOM
+import qualified GHCJS.DOM as DOM
+import qualified GHCJS.DOM.EventM as DOM
+import qualified "ghcjs-dom" GHCJS.DOM.Document as DOM
 import           Reflex.Dom.Builder.Immediate (wrapDomEvent)
 ------------------------------------------------------------------------------
 import           Chainweb.Api.BlockHeader

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -383,7 +383,9 @@ mainPageWidget netId (Just height) = do
     appState <- ask
     let si = _as_serverInfo appState
     (dbt', stats, mrecent) <- initBlockTable height
-    dbt <- downsampleDynamic dbt'
+    dbt <- if netId == NetId_FastDevelopment
+      then downsampleDynamic dbt'
+      else return dbt'
     let maxBlockHeight = blockTableMaxHeight <$> dbt
 
     searchWidget netId

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -92,6 +92,8 @@ mainDispatch route ndbs = do
       aboutWidget
     FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet
     FR_Testnet -> networkDispatch route ndbs NetId_Testnet
+    FR_Development -> networkDispatch route ndbs NetId_Development
+    FR_FastDevelopment -> networkDispatch route ndbs NetId_FastDevelopment
     FR_Customnet -> subPairRoute_ $ \host ->
       networkDispatch route ndbs (NetId_Custom host)
 

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -87,7 +87,7 @@ mainDispatch route ndbs = do
   pb <- getPostBuild
   subRoute_ $ \case
     FR_Main -> setRoute ((FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
-    FR_About -> do
+    FR_About -> prerender_ blank $ do
       divClass "ui fixed inverted menu" $ nav NetId_Mainnet
       aboutWidget
     FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -91,17 +91,16 @@ mainDispatch
 mainDispatch route ndbs = do
   pb <- getPostBuild
   subRoute_ $ \case
-    FR_Prefix -> subRoute_ $ \case
-      FR_Main -> setRoute ((FR_Prefix :/ FR_FastDevelopment :/ NetRoute_Chainweb :/ ()) <$ pb)
-      FR_About -> prerender_ blank $ do
-        divClass "ui fixed inverted menu" $ nav NetId_FastDevelopment
-        aboutWidget
-      FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet
-      FR_Testnet -> networkDispatch route ndbs NetId_Testnet
-      FR_Development -> networkDispatch route ndbs NetId_Development
-      FR_FastDevelopment -> networkDispatch route ndbs NetId_FastDevelopment
-      FR_Customnet -> subPairRoute_ $ \host ->
-        networkDispatch route ndbs (NetId_Custom host)
+    FR_Main -> setRoute ((FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
+    FR_About -> prerender_ blank $ do
+      divClass "ui fixed inverted menu" $ nav NetId_Mainnet
+      aboutWidget
+    FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet
+    FR_Testnet -> networkDispatch route ndbs NetId_Testnet
+    FR_Development -> networkDispatch route ndbs NetId_Development
+    FR_FastDevelopment -> networkDispatch route ndbs NetId_FastDevelopment
+    FR_Customnet -> subPairRoute_ $ \host ->
+      networkDispatch route ndbs (NetId_Custom host)
 
 networkDispatch
   :: (ObeliskWidget js t (R FrontendRoute) m)

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -477,7 +477,7 @@ mainPageWidget netId (Just height) = do
       in (d, h, m , s)
 
     -- Filter down updates to the main page widget `Dynamic`s so that we don't
-    -- re-render more than once a second and also when the page is not visible.
+    -- re-render too frequently and also when the page is not visible.
     cullMainPageUpdates :: Dynamic t a -> RoutedT t r m (Dynamic t a)
     cullMainPageUpdates d = do
       -- 1. Visibility Filtering
@@ -486,7 +486,7 @@ mainPageWidget netId (Just height) = do
       let visibilityFilteredE = gate isVisible (updated d)
 
       -- 2. Time-based Downsampling
-      throttledE <- throttle 1 visibilityFilteredE
+      throttledE <- throttle 2 visibilityFilteredE
 
       -- Construct final Dynamic
       initval <- sample $ current d

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -86,16 +86,17 @@ mainDispatch
 mainDispatch route ndbs = do
   pb <- getPostBuild
   subRoute_ $ \case
-    FR_Main -> setRoute ((FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
-    FR_About -> prerender_ blank $ do
-      divClass "ui fixed inverted menu" $ nav NetId_Mainnet
-      aboutWidget
-    FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet
-    FR_Testnet -> networkDispatch route ndbs NetId_Testnet
-    FR_Development -> networkDispatch route ndbs NetId_Development
-    FR_FastDevelopment -> networkDispatch route ndbs NetId_FastDevelopment
-    FR_Customnet -> subPairRoute_ $ \host ->
-      networkDispatch route ndbs (NetId_Custom host)
+    FR_Prefix -> subRoute_ $ \case
+      FR_Main -> setRoute ((FR_Prefix :/ FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
+      FR_About -> prerender_ blank $ do
+        divClass "ui fixed inverted menu" $ nav NetId_Mainnet
+        aboutWidget
+      FR_Mainnet -> networkDispatch route ndbs NetId_Mainnet
+      FR_Testnet -> networkDispatch route ndbs NetId_Testnet
+      FR_Development -> networkDispatch route ndbs NetId_Development
+      FR_FastDevelopment -> networkDispatch route ndbs NetId_FastDevelopment
+      FR_Customnet -> subPairRoute_ $ \host ->
+        networkDispatch route ndbs (NetId_Custom host)
 
 networkDispatch
   :: (ObeliskWidget js t (R FrontendRoute) m)

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -91,7 +91,9 @@ mainDispatch
 mainDispatch route ndbs = do
   pb <- getPostBuild
   subRoute_ $ \case
-    FR_Main -> setRoute ((FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
+    FR_Main -> do
+      r <- mainRoute
+      setRoute (r <$ pb)
     FR_About -> prerender_ blank $ do
       divClass "ui fixed inverted menu" $ nav NetId_Mainnet
       aboutWidget

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -87,7 +87,7 @@ mainDispatch route ndbs = do
   pb <- getPostBuild
   subRoute_ $ \case
     FR_Prefix -> subRoute_ $ \case
-      FR_Main -> setRoute ((FR_Prefix :/ FR_Mainnet :/ NetRoute_Chainweb :/ ()) <$ pb)
+      FR_Main -> setRoute ((FR_Prefix :/ FR_FastDevelopment :/ NetRoute_Chainweb :/ ()) <$ pb)
       FR_About -> prerender_ blank $ do
         divClass "ui fixed inverted menu" $ nav NetId_FastDevelopment
         aboutWidget

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -415,8 +415,10 @@ mainPageWidget netId (Just height) = do
 
     _ <- divClass "ui segment" $ do
       elDynAttr "div" (statAttrs <$> stats) $ do
-          statistic "Est. Network Hash Rate" (dynText $ maybe "-" ((<>"/s") . diffStr) <$> hashrate)
-          statistic "Total Difficulty" (dynText $ diffStr . totalDifficulty <$> dbt)
+          -- These statistics are nonsensical on fast-development
+          unless (netId == NetId_FastDevelopment) $ do
+            statistic "Est. Network Hash Rate" (dynText $ maybe "-" ((<>"/s") . diffStr) <$> hashrate)
+            statistic "Total Difficulty" (dynText $ diffStr . totalDifficulty <$> dbt)
 
           networkView $ ffor (statsList <$> stats) $ \ps -> do
             forM ps $ \(n,v) -> statistic n $ text v

--- a/frontend/src/Frontend/Nav.hs
+++ b/frontend/src/Frontend/Nav.hs
@@ -24,6 +24,12 @@ import           Common.Route
 import           Common.Types
 ------------------------------------------------------------------------------
 
+-- We want to avoid a double setRoute in the navigation bar, so we link directly
+-- to the target of the main route. We declare mainRoute as a monadic type because
+-- we might need to do some dynamic routing in the future without changing call sites.
+mainRoute :: Monad m => m (R FrontendRoute)
+mainRoute = return $ FR_Mainnet :/ NetRoute_Chainweb :/ ()
+
 nav
   :: (DomBuilder t m, MonadHold t m, PostBuild t m, MonadFix m,
       RouteToUrl (R FrontendRoute) m, SetRoute t (R FrontendRoute) m, Routed t r m)
@@ -31,7 +37,7 @@ nav
   -> m ()
 nav netId = do
   divClass "ui container" $ do
-    let mainLink = routeLinkAttr (FR_Main :/ ())
+    mainLink <- routeLinkAttr <$> mainRoute
     mainLink ("class" =: "header item" <> "style" =: "color: #e8098f;") $
       elAttr "img" ("class" =: "logo" <>
                     "src" =: static @"kadena-k-logo.png") $

--- a/frontend/src/Frontend/Nav.hs
+++ b/frontend/src/Frontend/Nav.hs
@@ -31,13 +31,13 @@ nav
   -> m ()
 nav netId = do
   divClass "ui container" $ do
-    elAttr "a" ("class" =: "header item" <>
-                "href" =: "/" <>
-                "style" =: "color: #e8098f;") $
+    let mainLink = routeLinkAttr (FR_Prefix :/ FR_Main :/ ())
+    mainLink ("class" =: "header item" <> "style" =: "color: #e8098f;") $
       elAttr "img" ("class" =: "logo" <>
                     "src" =: static @"kadena-k-logo.png") $
         text "Kadena Block Explorer"
-    elAttr "a" ("class" =: "header item" <> "href" =: "/") $ text "Kadena Block Explorer"
+    routeLinkAttr (FR_Prefix :/ FR_Main :/ ()) ("class" =: "header item") $
+      text "Kadena Block Explorer"
     divClass "right menu" $ do
       routeLinkAttr (FR_Prefix :/ FR_About :/ ()) ("class" =: "item") $ text "About"
       getStarted

--- a/frontend/src/Frontend/Nav.hs
+++ b/frontend/src/Frontend/Nav.hs
@@ -31,15 +31,15 @@ nav
   -> m ()
 nav netId = do
   divClass "ui container" $ do
-    let mainLink = routeLinkAttr (FR_Prefix :/ FR_Main :/ ())
+    let mainLink = routeLinkAttr (FR_Main :/ ())
     mainLink ("class" =: "header item" <> "style" =: "color: #e8098f;") $
       elAttr "img" ("class" =: "logo" <>
                     "src" =: static @"kadena-k-logo.png") $
         text "Kadena Block Explorer"
-    routeLinkAttr (FR_Prefix :/ FR_Main :/ ()) ("class" =: "header item") $
+    routeLinkAttr (FR_Main :/ ()) ("class" =: "header item") $
       text "Kadena Block Explorer"
     divClass "right menu" $ do
-      routeLinkAttr (FR_Prefix :/ FR_About :/ ()) ("class" =: "item") $ text "About"
+      routeLinkAttr (FR_About :/ ()) ("class" =: "item") $ text "About"
       getStarted
       learnMore
       networkWidget netId
@@ -112,7 +112,8 @@ networkWidget netId = mdo
     text $ networkName netId
     let mkAttrs as vis = "class" =: (if vis then (as <> " visible") else as)
     elDynAttr "div" (mkAttrs "menu transition" <$> dropdownVisible) $ do
-      networkItem "FastDevelopment" $ FR_Prefix :/ FR_FastDevelopment :/ NetRoute_Chainweb :/ ()
+      networkItem "Testnet" $ FR_Testnet :/ NetRoute_Chainweb :/ ()
+      networkItem "Mainnet" $ FR_Mainnet :/ NetRoute_Chainweb :/ ()
   route <- askRoute
   dropdownVisible <- holdDyn False $ leftmost
     [ True <$ domEvent Mouseenter e

--- a/frontend/src/Frontend/Nav.hs
+++ b/frontend/src/Frontend/Nav.hs
@@ -39,7 +39,7 @@ nav netId = do
         text "Kadena Block Explorer"
     elAttr "a" ("class" =: "header item" <> "href" =: "/") $ text "Kadena Block Explorer"
     divClass "right menu" $ do
-      linkItem "About" "/about"
+      routeLinkAttr (FR_Prefix :/ FR_About :/ ()) ("class" =: "item") $ text "About"
       getStarted
       learnMore
       networkWidget netId
@@ -112,8 +112,8 @@ networkWidget netId = mdo
     text $ networkName netId
     let mkAttrs as vis = "class" =: (if vis then (as <> " visible") else as)
     elDynAttr "div" (mkAttrs "menu transition" <$> dropdownVisible) $ do
-      networkItem "Testnet" $ FR_Testnet :/ NetRoute_Chainweb :/ ()
-      networkItem "Mainnet" $ FR_Mainnet :/ NetRoute_Chainweb :/ ()
+      networkItem "Testnet" $ FR_Prefix :/ FR_Testnet :/ NetRoute_Chainweb :/ ()
+      networkItem "Mainnet" $ FR_Prefix :/ FR_Mainnet :/ NetRoute_Chainweb :/ ()
   route <- askRoute
   dropdownVisible <- holdDyn False $ leftmost
     [ True <$ domEvent Mouseenter e

--- a/frontend/src/Frontend/Nav.hs
+++ b/frontend/src/Frontend/Nav.hs
@@ -112,8 +112,7 @@ networkWidget netId = mdo
     text $ networkName netId
     let mkAttrs as vis = "class" =: (if vis then (as <> " visible") else as)
     elDynAttr "div" (mkAttrs "menu transition" <$> dropdownVisible) $ do
-      networkItem "Testnet" $ FR_Prefix :/ FR_Testnet :/ NetRoute_Chainweb :/ ()
-      networkItem "Mainnet" $ FR_Prefix :/ FR_Mainnet :/ NetRoute_Chainweb :/ ()
+      networkItem "FastDevelopment" $ FR_Prefix :/ FR_FastDevelopment :/ NetRoute_Chainweb :/ ()
   route <- askRoute
   dropdownVisible <- holdDyn False $ leftmost
     [ True <$ domEvent Mouseenter e

--- a/frontend/src/Frontend/Nav.hs
+++ b/frontend/src/Frontend/Nav.hs
@@ -98,6 +98,8 @@ linkItemNewTab nm url = do
 networkName :: NetId -> Text
 networkName NetId_Mainnet = "Mainnet"
 networkName NetId_Testnet = "Testnet"
+networkName NetId_Development = "Development"
+networkName NetId_FastDevelopment = "FastDevelopment"
 networkName (NetId_Custom _) = "Custom Network"
 
 networkWidget


### PR DESCRIPTION
This PR adds devnet support to the block-explorer. It makes the following changes for a streamlined explorer experience for (fast-)development.

* In addition to the `mainnet` and `testnet` top-level routes, `development` and `fast-development` routes are now also supported.
* Reduce the updates to the live chainweb view at the main page:
   * Throttle the updates to at most once per 2 seconds 
   * Avoid updates while the page isn't visible
    
   These changes were essential for fast-devnet due to the increased block rate, but should be useful for mainnet as well.
* Hide the difficulty and network hash rate statistics for fast-development
* Use `obelisk`s routes for linking from the navigation bar to `FR_About` and `FR_Main` in order to reuse the routing logic and also avoid a round-trip through the server. 
* Added `prerender_ blank` to the "About" route, this avoids a rendering issue when the explorer is deployed as a JS-only SPA.
