### PR TITLE
Centralize def netcfg handing in networkDispatch

### DIFF
--- a/frontend/src/Frontend/Accounts.hs
+++ b/frontend/src/Frontend/Accounts.hs
@@ -87,9 +87,9 @@ accountWidget
   -> Text
   -> App r t m ()
 accountWidget token account = do
-  (AppState n si _ _) <- ask
+  (AppState _ si nc _) <- ask
   let chains = S.toList $ _siChains si
-      chainwebHost = ChainwebHost (netHost n) (_siChainwebVer si)
+      chainwebHost = ChainwebHost nc (_siChainwebVer si)
   curTime <- liftIO getCurrentTime
   let meta chain = ChainwebMeta
         (tshow $ unChainId chain)

--- a/frontend/src/Frontend/App.hs
+++ b/frontend/src/Frontend/App.hs
@@ -57,13 +57,13 @@ runApp
 --  :: (DomBuilder t m, Routed t r m, MonadHold t m, MonadFix m, Prerender js t m, PostBuild t m, MonadJSM (Performable m), HasJSContext (Performable m), PerformEvent t m, TriggerEvent t m)
   :: (DomBuilder t m, Routed t r m, MonadFix m)
   => Text
-  -> DataBackends
+  -> Maybe DataBackends
   -> NetId
   -> ServerInfo
   -> RoutedT t r (ReaderT (AppState t) (EventWriterT t AppTriggers m)) a
   -> m a
-runApp publicUrl ndbs net si m = mdo
+runApp publicUrl mdbs net si m = mdo
     r <- askRoute
-    as <- stateManager publicUrl ndbs net si triggers
+    as <- stateManager publicUrl mdbs net si triggers
     (res, triggers) <- runEventWriterT (runReaderT (runRoutedT m r) as)
     return res

--- a/frontend/src/Frontend/AppState.hs
+++ b/frontend/src/Frontend/AppState.hs
@@ -152,7 +152,7 @@ setStartTime t gs = gs { _gs_startTime = t }
 data AppState t = AppState
     { _as_network    :: NetId
     , _as_serverInfo :: ServerInfo
-    , _as_netConfig :: Maybe NetConfig
+    , _as_netConfig :: NetConfig
     , _as_graphAdjacencies :: SM.Map Int Int
     } deriving Generic
 
@@ -171,15 +171,15 @@ stateManager
     :: DomBuilder t m
     => Text
     -- ^ Application route...not in use yet
-    -> DataBackends
+    -> Maybe DataBackends
     -> NetId
     -> ServerInfo
     -> Event t AppTriggers
     -- ^ Not in use yet
     -> m (AppState t)
-stateManager _ (DataBackends ndbs) n si _ = do
+stateManager _ mdbs n si _ = do
     let adjs = maybe mempty (SM.fromList . zip [0..] . floydWarshall . M.fromList . snd . head) $ _siGraphs si
-    return $ AppState n si (M.lookup (_siChainwebVer si) ndbs) adjs
+    return $ AppState n si (lookupNetConfigWithDefault n mdbs) adjs
 
 pairToBhtx :: (BlockHeader, Text) -> BlockHeaderTx
 pairToBhtx (h, bhBinBase64) =

--- a/frontend/src/Frontend/Page/Block.hs
+++ b/frontend/src/Frontend/Page/Block.hs
@@ -59,8 +59,7 @@ blockHashWidget
   -> App (Text, R BlockRoute) t m ()
 blockHashWidget si netId cid = do
   as <- ask
-  let n = _as_network as
-      chainwebHost = ChainwebHost (netHost n) (_siChainwebVer si)
+  let chainwebHost = ChainwebHost (_as_netConfig as) (_siChainwebVer si)
       c = ChainId cid
   subPairRoute_ $ \hash -> do
     ebh <- getBlockHeader chainwebHost c hash
@@ -79,8 +78,7 @@ blockHeightWidget
   -> App (Int, R BlockRoute) t m ()
 blockHeightWidget si netId cid = do
   as <- ask
-  let n = _as_network as
-      chainwebHost = ChainwebHost (netHost n) (_siChainwebVer si)
+  let chainwebHost = ChainwebHost (_as_netConfig as) (_siChainwebVer si)
       c = ChainId cid
   subPairRoute_ $ \height -> do
     ebh <- getBlockHeaderByHeight chainwebHost c height

--- a/frontend/src/Frontend/Page/ReqKey.hs
+++ b/frontend/src/Frontend/Page/ReqKey.hs
@@ -74,8 +74,7 @@ requestKeyWidget
 requestKeyWidget si netId = do
     as <- ask
     reqKey <- askRoute
-    let n = _as_network as
-        chainwebHost = ChainwebHost (netHost n) (_siChainwebVer si)
+    let chainwebHost = ChainwebHost (_as_netConfig as) (_siChainwebVer si)
         xhrs rk = M.fromList $ map (\c -> (c, requestKeyXhr chainwebHost c rk)) $
                       S.toList $ _siChains si
 
@@ -103,8 +102,8 @@ requestKeyWidget si netId = do
         Right (PollResponses pr) -> if HM.null pr
                                     then Nothing
                                     else pure $ Right pr
-    reqParseErrorMsg e rk = do 
-      el "div" $ dynText $ 
+    reqParseErrorMsg e rk = do
+      el "div" $ dynText $
         fmap ("An unexpected error occured when processing request key: " <>) rk
       el "div" $ text "Help us make our tools better by filing an issue with the below message at www.github.com/kadena-io/block-explorer :"
       el "div" $ text e

--- a/frontend/src/Frontend/Transactions.hs
+++ b/frontend/src/Frontend/Transactions.hs
@@ -80,39 +80,36 @@ transactionSearch
        )
     => App (Map Text (Maybe Text)) t m ()
 transactionSearch = do
-    (AppState n _ mnc _) <- ask
-    case mnc of
-      Nothing -> text "Transaction search feature not available for this network"
-      Just nc -> do
-        pmap <- askRoute
-        pb <- getPostBuild
-        let page = do
-              pm <- pmap
-              pure $ fromMaybe 1 $ readMaybe . T.unpack =<< join (M.lookup pageParam pm)
-            needle = do
-              pm <- pmap
-              pure $ fromMaybe "" $ join (M.lookup qParam pm)
-            newSearch = leftmost [pb, () <$ updated pmap]
+    (AppState n _ nc _) <- ask
+    pmap <- askRoute
+    pb <- getPostBuild
+    let page = do
+          pm <- pmap
+          pure $ fromMaybe 1 $ readMaybe . T.unpack =<< join (M.lookup pageParam pm)
+        needle = do
+          pm <- pmap
+          pure $ fromMaybe "" $ join (M.lookup qParam pm)
+        newSearch = leftmost [pb, () <$ updated pmap]
 
-        res <- searchTxs nc
-                 (constDyn $ Just $ Limit itemsPerPage)
-                 (Just . Offset . (*itemsPerPage) . pred <$> page)
-                 (QParamSome <$> needle) (constDyn QNone) (constDyn QNone) (constDyn QNone) newSearch
+    res <- searchTxs nc
+              (constDyn $ Just $ Limit itemsPerPage)
+              (Just . Offset . (*itemsPerPage) . pred <$> page)
+              (QParamSome <$> needle) (constDyn QNone) (constDyn QNone) (constDyn QNone) newSearch
 
-        divClass "ui pagination menu" $ do
-          let setSearchRoute f e = setRoute $
-                tag (current $ mkTxSearchRoute n <$> needle <*> fmap (Just . f) page) e
-              prevAttrs p = if p == 1
-                              then "class" =: "disabled item"
-                              else "class" =: "item"
-          (p,_) <- elDynAttr' "div" (prevAttrs <$> page) $ text "Prev"
-          setSearchRoute pred (domEvent Click p)
-          divClass "disabled item" $ display page
-          (next,_) <- elAttr' "div" ("class" =: "item") $ text "Next"
-          setSearchRoute succ (domEvent Click next)
+    divClass "ui pagination menu" $ do
+      let setSearchRoute f e = setRoute $
+            tag (current $ mkTxSearchRoute n <$> needle <*> fmap (Just . f) page) e
+          prevAttrs p = if p == 1
+                          then "class" =: "disabled item"
+                          else "class" =: "item"
+      (p,_) <- elDynAttr' "div" (prevAttrs <$> page) $ text "Prev"
+      setSearchRoute pred (domEvent Click p)
+      divClass "disabled item" $ display page
+      (next,_) <- elAttr' "div" ("class" =: "item") $ text "Next"
+      setSearchRoute succ (domEvent Click next)
 
-        let f = either text (txTable n "Transaction Search")
-        void $ networkHold (inlineLoader "Querying blockchain...") (f <$> res)
+    let f = either text (txTable n "Transaction Search")
+    void $ networkHold (inlineLoader "Querying blockchain...") (f <$> res)
 
 mkReqKeySearchRoute :: NetId -> Text -> R FrontendRoute
 mkReqKeySearchRoute netId str = mkNetRoute netId (NetRoute_TxReqKey :/ str)
@@ -135,43 +132,40 @@ eventSearch
        )
     => App (Map Text (Maybe Text)) t m ()
 eventSearch = do
-    (AppState n _ mnc _) <- ask
-    case mnc of
-      Nothing -> text "Event search feature not available for this network"
-      Just nc -> do
-        pmap <- askRoute
-        pb <- getPostBuild
-        let page = do
-              pm <- pmap
-              pure $ fromMaybe 1 $ readMaybe . T.unpack =<< join (M.lookup pageParam pm)
-            needle = do
-              pm <- pmap
-              pure $ fromMaybe "" $ join (M.lookup qParam pm)
-            newSearch = leftmost [pb, () <$ updated pmap]
-        res <- searchEvents nc
-            (constDyn $ Just $ Limit itemsPerPage)
-            (Just . Offset . (*itemsPerPage) . pred <$> page)
-            (QParamSome <$> needle)
-            (constDyn QNone) 
-            (constDyn QNone)
-            (constDyn QNone)
-            (constDyn QNone)
-            (constDyn QNone)
-            newSearch
-        divClass "ui pagination menu" $ do
-          let setSearchRoute f e = setRoute $
-                tag (current $ mkEventSearchRoute n <$> needle <*> fmap (Just . f) page) e
-              prevAttrs p = if p == 1
-                              then "class" =: "disabled item"
-                              else "class" =: "item"
-          (p,_) <- elDynAttr' "div" (prevAttrs <$> page) $ text "Prev"
-          setSearchRoute pred (domEvent Click p)
-          divClass "disabled item" $ display page
-          (next,_) <- elAttr' "div" ("class" =: "item") $ text "Next"
-          setSearchRoute succ (domEvent Click next)
+    (AppState n _ nc _) <- ask
+    pmap <- askRoute
+    pb <- getPostBuild
+    let page = do
+          pm <- pmap
+          pure $ fromMaybe 1 $ readMaybe . T.unpack =<< join (M.lookup pageParam pm)
+        needle = do
+          pm <- pmap
+          pure $ fromMaybe "" $ join (M.lookup qParam pm)
+        newSearch = leftmost [pb, () <$ updated pmap]
+    res <- searchEvents nc
+        (constDyn $ Just $ Limit itemsPerPage)
+        (Just . Offset . (*itemsPerPage) . pred <$> page)
+        (QParamSome <$> needle)
+        (constDyn QNone)
+        (constDyn QNone)
+        (constDyn QNone)
+        (constDyn QNone)
+        (constDyn QNone)
+        newSearch
+    divClass "ui pagination menu" $ do
+      let setSearchRoute f e = setRoute $
+            tag (current $ mkEventSearchRoute n <$> needle <*> fmap (Just . f) page) e
+          prevAttrs p = if p == 1
+                          then "class" =: "disabled item"
+                          else "class" =: "item"
+      (p,_) <- elDynAttr' "div" (prevAttrs <$> page) $ text "Prev"
+      setSearchRoute pred (domEvent Click p)
+      divClass "disabled item" $ display page
+      (next,_) <- elAttr' "div" ("class" =: "item") $ text "Next"
+      setSearchRoute succ (domEvent Click next)
 
-        let f = either text (evTable n)
-        void $ networkHold (inlineLoader "Querying blockchain...") (f <$> res)
+    let f = either text (evTable n)
+    void $ networkHold (inlineLoader "Querying blockchain...") (f <$> res)
 
 mkEventSearchRoute :: NetId -> Text -> Maybe Integer -> R FrontendRoute
 mkEventSearchRoute netId str page = mkNetRoute netId (NetRoute_EventSearch :/ (qParam =: Just str <> p ))

--- a/frontend/src/Frontend/Transfer.hs
+++ b/frontend/src/Frontend/Transfer.hs
@@ -77,9 +77,9 @@ transferHelper
   -> App r t m ()
 transferHelper aps = do
      (AppState _ _ cw _) <- ask
-     case cw >>= _netConfig_dataHost of
+     case _netConfig_dataHost cw of
        Nothing -> text "Transfers view is not supported unless a chainweb-data url is included in the config!"
-       Just _dataHost -> transferWidget aps (fromJust cw) -- We can assume the netconfig exists if we got to this branch!
+       Just _dataHost -> transferWidget aps cw -- We can assume the netconfig exists if we got to this branch!
 
 transferWidget
   :: ( MonadApp r t m


### PR DESCRIPTION
This PR centralizes the handling of the default netconfig avoiding the `Maybe` , so that we peel off the `Maybe` layer of the `_as_netConfig` field of the `AppState`, meaning that we don't have to deal with the missing configuration case in an ad-hoc manner in all call sites separately.