### PR TITLE
Fix layout issues from wide cells

### DIFF
--- a/frontend/src/Frontend/Common.hs
+++ b/frontend/src/Frontend/Common.hs
@@ -72,15 +72,22 @@ detailsSection :: DomBuilder t m => m a -> m a
 detailsSection c = do
   elClass "table" "ui fixed line definition table" $ el "tbody" c
 
+-- See tfieldLeaf
 tfield :: DomBuilder t m => Text -> m a -> m a
 tfield nm v = el "tr" $ do
   elClass "td" "two wide" $ text nm
   el "td" v
 
-tfieldPre :: DomBuilder t m => Text -> m a -> m a
-tfieldPre nm v = el "tr" $ do
+-- We use tfield for displaying the field of potentially nested data structures
+-- tfieldLeaf should be used for displaying the leaf nodes of a data structure
+-- allowing the scrolling to work properly when a cell is too wide
+tfieldLeaf :: DomBuilder t m => Text -> m a -> m a
+tfieldLeaf nm v = el "tr" $ do
   elClass "td" "two wide" $ text nm
-  el "td" $ el "pre" v
+  elClass "td" "leaf-cell" v
+
+tfieldPre :: DomBuilder t m => Text -> m a -> m a
+tfieldPre nm v = tfieldLeaf nm $ el "pre" v
 
 jsonTable :: DomBuilder t m => Value -> m ()
 jsonTable (Object o) = detailsSection $ forM_ (HM.toList o) $ \(k,v) -> do

--- a/frontend/src/Frontend/Page/Block.hs
+++ b/frontend/src/Frontend/Page/Block.hs
@@ -159,20 +159,20 @@ blockHeaderPage netId h c (bh, bhBinBase64) bp resolveOrphan = do
     el "h2" $ dynText ( ("Block Header " <>) <$> orphanText)
     elAttr "table" ("class" =: "ui definition table") $ do
       el "tbody" $ do
-        tfield "Creation Time" $ text $ tshow $ posixSecondsToUTCTime $ _blockHeader_creationTime bh
-        tfield "Chain" $ text $ tshow $ _blockHeader_chainId bh
-        tfield "Block Height" $ text $ tshow $ _blockHeader_height bh
-        tfield "Parent" $ parent $ _blockHeader_parent bh
-        tfield "POW Hash" $ text $ either (const "") id (calcPowHash =<< decodeB64UrlNoPaddingText bhBinBase64)
-        tfield "Target" $ text $ hexFromBytesLE $ _blockHeader_target bh
-        tfield "Hash" $ text $ hashHex $ _blockHeader_hash bh
-        tfield "Weight" $ text $ hexFromBytesLE $ _blockHeader_weight bh
-        tfield "Epoch Start" $ text $ tshow $ posixSecondsToUTCTime $ _blockHeader_epochStart bh
-        tfield "Neighbors" $ neighbors $ _blockHeader_neighbors bh
-        tfield "Payload Hash" $ text $ hashB64U $ _blockHeader_payloadHash bh
-        tfield "Chainweb Version" $ text $ _blockHeader_chainwebVer bh
-        tfield "Flags" $ text $ T.pack $ printf "0x%08x" (_blockHeader_flags bh)
-        tfield "Nonce" $ text $ T.pack $ showHex (_blockHeader_nonce bh) ""
+        tfieldLeaf "Creation Time" $ text $ tshow $ posixSecondsToUTCTime $ _blockHeader_creationTime bh
+        tfieldLeaf "Chain" $ text $ tshow $ _blockHeader_chainId bh
+        tfieldLeaf "Block Height" $ text $ tshow $ _blockHeader_height bh
+        tfieldLeaf "Parent" $ parent $ _blockHeader_parent bh
+        tfieldLeaf "POW Hash" $ text $ either (const "") id (calcPowHash =<< decodeB64UrlNoPaddingText bhBinBase64)
+        tfieldLeaf "Target" $ text $ hexFromBytesLE $ _blockHeader_target bh
+        tfieldLeaf "Hash" $ text $ hashHex $ _blockHeader_hash bh
+        tfieldLeaf "Weight" $ text $ hexFromBytesLE $ _blockHeader_weight bh
+        tfieldLeaf "Epoch Start" $ text $ tshow $ posixSecondsToUTCTime $ _blockHeader_epochStart bh
+        tfieldLeaf "Neighbors" $ neighbors $ _blockHeader_neighbors bh
+        tfieldLeaf "Payload Hash" $ text $ hashB64U $ _blockHeader_payloadHash bh
+        tfieldLeaf "Chainweb Version" $ text $ _blockHeader_chainwebVer bh
+        tfieldLeaf "Flags" $ text $ T.pack $ printf "0x%08x" (_blockHeader_flags bh)
+        tfieldLeaf "Nonce" $ text $ T.pack $ showHex (_blockHeader_nonce bh) ""
         return ()
     blockPayloadWithOutputsWidget netId c bh bp
   where
@@ -208,16 +208,16 @@ blockPayloadWidget netId c bh bp = do
     el "h2" $ text "Block Payload"
     elAttr "table" ("class" =: "ui definition table") $ do
       el "tbody" $ do
-        tfield "Miner" $ do
+        tfieldLeaf "Miner" $ do
           let account = _minerData_account (_blockPayload_minerData bp)
           el "div" $ routeLink (mkCoinAccountSearchRoute netId account) $
             text $ "Account: " <> account
           el "div" $ text $ "Public Keys: " <> tshow (_minerData_publicKeys $ _blockPayload_minerData bp)
           el "div" $ text $ "Predicate: " <> _minerData_predicate (_blockPayload_minerData bp)
-        tfield "Transactions Hash" $ text $ hashB64U $ _blockPayload_transactionsHash bp
-        tfield "Outputs Hash" $ text $ hashB64U $ _blockPayload_outputsHash bp
-        tfield "Payload Hash" $ text $ hashB64U $ _blockPayload_payloadHash bp
-        tfield "Transactions" $ transactionsLink netId c $ _blockHeader_hash bh
+        tfieldLeaf "Transactions Hash" $ text $ hashB64U $ _blockPayload_transactionsHash bp
+        tfieldLeaf "Outputs Hash" $ text $ hashB64U $ _blockPayload_outputsHash bp
+        tfieldLeaf "Payload Hash" $ text $ hashB64U $ _blockPayload_payloadHash bp
+        tfieldLeaf "Transactions" $ transactionsLink netId c $ _blockHeader_hash bh
 
 blockPayloadWithOutputsWidget
   :: (MonadApp r t m,
@@ -233,32 +233,32 @@ blockPayloadWithOutputsWidget netId c bh bp = do
     el "h2" $ text "Block Payload"
     elAttr "table" ("class" =: "ui definition table") $ do
       el "tbody" $ do
-        tfield "Miner" $ do
+        tfieldLeaf "Miner" $ do
           let account = _minerData_account (_blockPayloadWithOutputs_minerData bp)
           el "div" $ routeLink (mkCoinAccountSearchRoute netId account) $
             text $ "Account: " <> account
           el "div" $ text $ "Public Keys: " <> tshow (_minerData_publicKeys $ _blockPayloadWithOutputs_minerData bp)
           el "div" $ text $ "Predicate: " <> _minerData_predicate (_blockPayloadWithOutputs_minerData bp)
-        tfield "Transactions Hash" $ text $ hashB64U $ _blockPayloadWithOutputs_transactionsHash bp
-        tfield "Outputs Hash" $ text $ hashB64U $ _blockPayloadWithOutputs_outputsHash bp
-        tfield "Payload Hash" $ text $ hashB64U $ _blockPayloadWithOutputs_payloadHash bp
+        tfieldLeaf "Transactions Hash" $ text $ hashB64U $ _blockPayloadWithOutputs_transactionsHash bp
+        tfieldLeaf "Outputs Hash" $ text $ hashB64U $ _blockPayloadWithOutputs_outputsHash bp
+        tfieldLeaf "Payload Hash" $ text $ hashB64U $ _blockPayloadWithOutputs_payloadHash bp
         let coinbase = fromCoinbase $ _blockPayloadWithOutputs_coinbase bp
         tfield "Coinbase Output" $ do
           elClass "table" "ui definition table" $ el "tbody" $ do
-          tfield "Gas" $ text $ tshow $ _toutGas coinbase
-          tfield "Result" $ text $ join either unwrapJSON $ fromPactResult $ _toutResult coinbase
-          tfield "Request Key" $ text $ hashB64U $ _toutReqKey coinbase
-          tfield "Logs" $ text $ (maybe "" hashB64U $ _toutLogs coinbase)
-          tfield "Metadata" $ renderMetaData netId c $ _toutMetaData coinbase
-          maybe (pure ()) (tfield "Continuation" . text . tshow) $ _toutContinuation coinbase
-          tfield "Transaction ID" $ maybe blank (text . tshow) $ _toutTxId coinbase
+            tfieldLeaf "Gas" $ text $ tshow $ _toutGas coinbase
+            tfieldLeaf "Result" $ text $ join either unwrapJSON $ fromPactResult $ _toutResult coinbase
+            tfieldLeaf "Request Key" $ text $ hashB64U $ _toutReqKey coinbase
+            tfieldLeaf "Logs" $ text $ (maybe "" hashB64U $ _toutLogs coinbase)
+            tfield "Metadata" $ renderMetaData netId c $ _toutMetaData coinbase
+            maybe (pure ()) (tfieldLeaf "Continuation" . text . tshow) $ _toutContinuation coinbase
+            tfieldLeaf "Transaction ID" $ maybe blank (text . tshow) $ _toutTxId coinbase
 
         let numberOfTransactions =
               case length $ _blockPayloadWithOutputs_transactionsWithOutputs bp of
                 n | n <= 0 -> "No transactions"
                   | n == 1 -> "1 Transaction"
                   | otherwise -> tshow n <> " Transactions"
-        tfield numberOfTransactions $ transactionsLink netId c $ _blockHeader_hash bh
+        tfieldLeaf numberOfTransactions $ transactionsLink netId c $ _blockHeader_hash bh
   where
     fromCoinbase (Coinbase cb) = cb
     fromPactResult (PactResult pr) = pr

--- a/frontend/src/Frontend/Page/Common.hs
+++ b/frontend/src/Frontend/Page/Common.hs
@@ -130,10 +130,10 @@ renderMetaData _ _ (Just A.Null) = text ""
 renderMetaData netId cid (Just v) = case fromJSON v of
     Success (PollMetaData bh bt bhash phash) -> do
       detailsSection $ do
-        tfield "Block Height" $ text $ tshow bh
-        tfield "Creation Time" $ text $ tshow $ posixSecondsToUTCTime bt
-        tfield "Block Hash" $ transactionsLink netId cid bhash
-        tfield "Parent Hash" $ transactionsLink netId cid phash
+        tfieldLeaf "Block Height" $ text $ tshow bh
+        tfieldLeaf "Creation Time" $ text $ tshow $ posixSecondsToUTCTime bt
+        tfieldLeaf "Block Hash" $ transactionsLink netId cid bhash
+        tfieldLeaf "Parent Hash" $ transactionsLink netId cid phash
     A.Error e -> text $ "Unable to decode metadata: " <> T.pack e
 
 -- | Render an object as a structured table, instead of raw json
@@ -148,7 +148,7 @@ renderRichObject m
       $ detailsSection
       $ HM.traverseWithKey go m
   where
-    go label v = tfield label $ text $ unwrapJSON v
+    go label v = tfieldLeaf label $ text $ unwrapJSON v
 
 -- | Render the 'Payload' of a 'Transaction'
 --
@@ -162,11 +162,11 @@ renderPayload = \case
         voidMaybe (tfieldPre "Data" . text . prettyJSON) d
     ContPayload (Cont pid rb step d p) -> do
       detailsSection $ do
-        tfield "Pact Id" $ text pid
-        tfield "Rollback" $ text $ tshow rb
-        tfield "Step" $ text $ tshow step
-        tfield "Data" $ text $ unwrapJSON d
-        tfield "Cont Proof" $ text $ fromMaybe "" p
+        tfieldLeaf "Pact Id" $ text pid
+        tfieldLeaf "Rollback" $ text $ tshow rb
+        tfieldLeaf "Step" $ text $ tshow step
+        tfieldLeaf "Data" $ text $ unwrapJSON d
+        tfieldLeaf "Cont Proof" $ text $ fromMaybe "" p
 
 -- | Render a 'PactExec' object in a 'CommandResult'
 --
@@ -181,14 +181,14 @@ renderPactExec
     -> m ()
 renderPactExec (PactExec stepCount y x step (PactId pid) pcont rb) netId res =
     detailsSection $ do
-      tfield "Step Count" $ text $ tshow stepCount
+      tfieldLeaf "Step Count" $ text $ tshow stepCount
       voidMaybe (tfield "Yield" . renderYield) y
-      voidMaybe (tfield "Executed" . text . tshow) x
-      tfield "Step" $ text $ tshow step
-      tfield "Pact Id" $ text pid
+      voidMaybe (tfieldLeaf "Executed" . text . tshow) x
+      tfieldLeaf "Step" $ text $ tshow step
+      tfieldLeaf "Pact Id" $ text pid
       tfield "Continuation" $ renderContinuation pcont
-      tfield "Rollback" $ text $ tshow rb
-      tfield "Next Step" $ case res of
+      tfieldLeaf "Rollback" $ text $ tshow rb
+      tfieldLeaf "Next Step" $ case res of
         Left err -> tfield "Error" $ text err
         Right xs -> case span ((== TxSucceeded) . _txSummary_result) xs of
           (ys,zs) -> do
@@ -218,8 +218,8 @@ renderProvenance
     -> m ()
 renderProvenance (Provenance (Pact.ChainId c) mhash) =
     detailsSection $ do
-      tfield "Target Chain" $ text c
-      tfield "Module Hash" $ text $ tshow mhash
+      tfieldLeaf "Target Chain" $ text c
+      tfieldLeaf "Module Hash" $ text $ tshow mhash
 
 -- | Render 'Yield' pact type
 --
@@ -229,7 +229,7 @@ renderYield
     -> m ()
 renderYield (Yield (ObjectMap m) p mCid) =
     detailsSection $ do
-      voidMaybe (tfield "Source Chain" . text . Pact._chainId) mCid
+      voidMaybe (tfieldLeaf "Source Chain" . text . Pact._chainId) mCid
       tfield "Data" $ renderRichObject $ yieldMap m
       voidMaybe (tfield "Provenance" . renderProvenance) p
   where

--- a/frontend/src/Frontend/Page/ReqKey.hs
+++ b/frontend/src/Frontend/Page/ReqKey.hs
@@ -124,18 +124,18 @@ requestKeyResultPage netId cid (CommandResult (RequestKey rk) txid pr (Gas g) lo
     el "h2" $ text "Transaction Results"
     elAttr "table" ("class" =: "ui definition table") $ do
       el "tbody" $ do
-        tfield "Chain" $ text $ tshow $ unChainId cid
-        tfield "Request Key" $ text rk
-        tfield "Transaction Id" $ text $ maybe "" tshow txid
-        tfield "Result" $ renderPactResult pr
-        tfield "Gas" $ text $ tshow g
-        tfield "Logs" $ text $ maybe "" unHash logs
-        tfield "Continuation" $ text $ maybe "" tshow pcont
+        tfieldLeaf "Chain" $ text $ tshow $ unChainId cid
+        tfieldLeaf "Request Key" $ text rk
+        tfieldLeaf "Transaction Id" $ text $ maybe "" tshow txid
+        tfieldLeaf "Result" $ renderPactResult pr
+        tfieldLeaf "Gas" $ text $ tshow g
+        tfieldLeaf "Logs" $ text $ maybe "" unHash logs
+        tfieldLeaf "Continuation" $ text $ maybe "" tshow pcont
         tfield "Metadata" $ renderMetaData netId cid meta
         tfield "Events" $ elClass "table" "ui definition table" $ el "tbody" $
                 forM_ evs $ \ ev -> el "tr" $ do
                   elClass "td" "two wide" $ mapM_ text (getEventName ev)
-                  elClass "td" "evtd" $ elClass "table" "evtable" $
+                  elClass "td" "evtd leaf-cell" $ elClass "table" "evtable" $
                     forM_ (Compose $ getEventParams ev) $ \v ->
                       elClass "tr" "evtable" $ elClass "td" "evtable" $
                         text $ unwrapJSON v

--- a/frontend/src/Frontend/Page/TxDetail.hs
+++ b/frontend/src/Frontend/Page/TxDetail.hs
@@ -88,9 +88,9 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
   el "h2" $ text $ "Transaction Detail"
   elClass "table" "ui definition table" $ do
     el "tbody" $ do
-      tfield "Request Key" $ text (_txDetail_requestKey $ firstTx)
-      tfield "Chain" $ text $ tshow $ (_txDetail_chain $ firstTx)
-      tfield "Block" $ do
+      tfieldLeaf "Request Key" $ text (_txDetail_requestKey $ firstTx)
+      tfieldLeaf "Chain" $ text $ tshow $ (_txDetail_chain $ firstTx)
+      tfieldLeaf "Block" $ do
         let tagIfOrphan cid height hash = if null restTxs
               then dynText $ constDyn mempty
               else do
@@ -102,9 +102,9 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
         forM_ txs $ \tx -> el "tr" $ do
             blockHashLink netId (ChainId (_txDetail_chain tx)) (_txDetail_blockHash tx) $ (_txDetail_blockHash tx)
             tagIfOrphan (ChainId $ _txDetail_chain tx) (_txDetail_height tx) (_txDetail_blockHash tx)
-      tfield "Code" $ case _txDetail_code firstTx of
-        Just c -> elAttr "pre" ("style" =: "white-space: pre-wrap;") $ text c
-        Nothing -> do
+      case _txDetail_code firstTx of
+        Just c -> tfieldLeaf "Code" $ elAttr "pre" ("style" =: "white-space: pre-wrap;") $ text c
+        Nothing -> tfield "Code" $ do
           let previousSteps = _txDetail_previousSteps firstTx
               initialCode = _txDetail_initialCode firstTx
               mkTxDetailRoute rk = mkNetRoute netId (NetRoute_TxDetail :/ rk)
@@ -113,23 +113,23 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
                 routeLink (mkTxDetailRoute rk) $ text rk
           elClass "table" "ui definition table" $ el "tbody" $ do
             case previousSteps of
-              Just steps -> tfield "Past Steps" $ do
+              Just steps -> tfieldLeaf "Past Steps" $ do
                 let l = length steps
                 iforM_ steps $ \i step -> do
                   txDetailLink step
                   unless (i >= l - 1) $ el "br" blank
               Nothing -> text "No previous steps?"
-            forM_ initialCode $ \c -> tfield "Initial Code" $ elAttr "pre" ("style" =: "white-space: pre-wrap;") $ text c
+            forM_ initialCode $ \c -> tfieldLeaf "Initial Code" $ elAttr "pre" ("style" =: "white-space: pre-wrap;") $ text c
       tfield "Transaction Output" $ do
         elClass "table" "ui definition table" $ el "tbody" $ do
-          tfield "Gas" $ text $ tshow $ _txDetail_gas firstTx
-          tfield "Result" $ do
+          tfieldLeaf "Gas" $ text $ tshow $ _txDetail_gas firstTx
+          tfieldLeaf "Result" $ do
             if _txDetail_success firstTx then
               elAttr "i" ("class" =: "green check icon" <> "title" =: "Succeeded") blank
                 else
               elAttr "i" ("class" =: "red close icon" <> "title" =: "Failed") blank
             text $ pactValueJSON $ _txDetail_result firstTx
-          tfield "Logs" $ text $ _txDetail_logs firstTx
+          tfieldLeaf "Logs" $ text $ _txDetail_logs firstTx
           tfield "Metadata" $ renderMetaData netId (ChainId $ _txDetail_chain firstTx) (Just $ _txDetail_metadata firstTx)
           tfield "Continuation" $ do
             pb <- getPostBuild
@@ -146,33 +146,33 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
                  (constDyn (QParamSome $ _txDetail_requestKey firstTx))
                  (constDyn QNone) (constDyn QNone) pb
               widgetHold_ (inlineLoader "Querying continuation info...") (renderCont c . ditchPartialResult <$> res)
-          tfield "Transaction ID" $ text $ tshow $ _txDetail_txid firstTx
+          tfieldLeaf "Transaction ID" $ text $ tshow $ _txDetail_txid firstTx
       tfield "Events" $ elClass "table" "ui definition table" $ el "tbody" $
         forM_ (_txDetail_events firstTx) $ \ ev -> el "tr" $ do
           elClass "td" "two wide" $ text (_txEvent_name ev)
-          elClass "td" "evtd" $ elClass "table" "evtable" $
+          elClass "td" "evtd leaf-cell" $ elClass "table" "evtable" $
             forM_ (_txEvent_params ev) $ \v ->
               elClass "tr" "evtable" $ elClass "td" "evtable" $ text $ pactValueJSON v
 
 
       tfieldPre "Data" $ text $ prettyJSON $ _txDetail_data firstTx
-      tfield "Nonce" $ text $ _txDetail_nonce firstTx
+      tfieldLeaf "Nonce" $ text $ _txDetail_nonce firstTx
       tfield "Meta" $ do
         elClass "table" "ui definition table" $ el "tbody" $ do
-          tfield "Chain" $ text $ tshow $ _txDetail_chain firstTx
-          tfield "Sender" $ text $ _txDetail_sender firstTx
-          tfield "Gas Price" $ text $ tshow $ _txDetail_gasPrice firstTx
-          tfield "Gas Limit" $ text $ tshow $ _txDetail_gasLimit firstTx
-          tfield "TTL" $ text $ tshow $ _txDetail_ttl firstTx
-          tfield "Creation Time" $ text $ tshow $ _txDetail_creationTime firstTx
+          tfieldLeaf "Chain" $ text $ tshow $ _txDetail_chain firstTx
+          tfieldLeaf "Sender" $ text $ _txDetail_sender firstTx
+          tfieldLeaf "Gas Price" $ text $ tshow $ _txDetail_gasPrice firstTx
+          tfieldLeaf "Gas Limit" $ text $ tshow $ _txDetail_gasLimit firstTx
+          tfieldLeaf "TTL" $ text $ tshow $ _txDetail_ttl firstTx
+          tfieldLeaf "Creation Time" $ text $ tshow $ _txDetail_creationTime firstTx
 
 
       tfield "Signers" $ do
         forM_ (_txDetail_signers firstTx) $ \s -> do
           elClass "table" "ui definition table" $ el "tbody" $ do
-            tfield "Public Key" $ text $ _signer_pubKey s
-            forM_ (_signer_addr s) $ tfield "Address" . text
-            forM_ (_signer_scheme s) $ tfield "Scheme" . text
+            tfieldLeaf "Public Key" $ text $ _signer_pubKey s
+            forM_ (_signer_addr s) $ tfieldLeaf "Address" . text
+            forM_ (_signer_scheme s) $ tfieldLeaf "Scheme" . text
             tfield "Signature Capabilities" $ do
               when (not $ null $ _signer_capList s) $ do
                 elClass "table" "ui celled table" $ do
@@ -184,11 +184,11 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
                   el "tbody" $
                     forM_ (_signer_capList s) $ \c -> el "tr" $ do
                       el "td" $ text $ _scName c
-                      elClass "td" "evtd" $ elClass "table" "evtable" $
+                      elClass "td" "evtd leaf-cell" $ elClass "table" "evtable" $
                         forM_ (_scArgs c) $ \arg -> elClass "tr" "evtable" $
                           elClass "td" "evtable" $ text $ unwrapJSON arg
       tfield "Signatures" $ do
-        elClass "table" "evtable" $
+        elClass "table" "evtable leaf-cell" $
           forM_ (_txDetail_sigs firstTx) $ \s ->
             elClass "tr" "evtable" $ elClass "td" "evtable" $ text $ unSig s
   where

--- a/frontend/src/Frontend/Transfer.hs
+++ b/frontend/src/Frontend/Transfer.hs
@@ -119,9 +119,9 @@ transferWidget AccountParams{..} nc = do
           elAttr "h2" ("data-tooltip" =: apAccount) $ text $ "Transfer Info"
           elClass "table" "ui definition table" $ do
             el "tbody" $ do
-              tfield "Token" $ text apToken
-              tfield "Account" $ accountSearchLink n apToken apAccount apAccount
-              maybe (pure ()) (\cid -> tfield "Chain ID" $ text $ tshow cid) apChain
+              tfieldLeaf "Token" $ text apToken
+              tfieldLeaf "Account" $ accountSearchLink n apToken apAccount apAccount
+              maybe (pure ()) (\cid -> tfieldLeaf "Chain ID" $ text $ tshow cid) apChain
           let initialMinHeight = maybe "" tshow apMinHeight
               initialMaxHeight = maybe "" tshow apMaxHeight
           elClass "div" "ui labeled input" $ do

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -55,6 +55,11 @@ td {
     vertical-align: middle;
 }
 
+.leaf-cell {
+  overflow-x: auto;
+  max-width: 200px;
+}
+
 div.header-row {
     border-top: 1px solid rgba(34, 36, 38, 0.1);
     border-bottom: 1px solid rgba(34, 36, 38, 0.1);


### PR DESCRIPTION
We're using nested tables for displaying complex nested data structures like blocks and transactions. The layout of this nested table structure gets distorted when a cell (potentially the cell of a nested table) becomes too wide and can't be line-wrapped.

This PR introduces a `tfieldLeaf` function as an alternative to `tfield`. `tfieldLeaf` allows us to make the "leaf" cells of these nested tables to be scrollable when needed.

Fixes #76 
Fixes #38 
