### PR TITLE
Fix layout issues from wide cells for Firefox

### DIFF
--- a/frontend/src/Frontend/Common.hs
+++ b/frontend/src/Frontend/Common.hs
@@ -84,7 +84,7 @@ tfield nm v = el "tr" $ do
 tfieldLeaf :: DomBuilder t m => Text -> m a -> m a
 tfieldLeaf nm v = el "tr" $ do
   elClass "td" "two wide" $ text nm
-  elClass "td" "leaf-cell" v
+  elClass "td" "leaf-cell-td" $ elClass "div" "leaf-cell-div" v
 
 tfieldPre :: DomBuilder t m => Text -> m a -> m a
 tfieldPre nm v = tfieldLeaf nm $ el "pre" v

--- a/frontend/src/Frontend/Page/ReqKey.hs
+++ b/frontend/src/Frontend/Page/ReqKey.hs
@@ -23,6 +23,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Functor.Compose (Compose(..))
 import Data.Foldable (traverse_)
 import qualified Data.HashMap.Strict as HM
+import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -133,9 +134,8 @@ requestKeyResultPage netId cid (CommandResult (RequestKey rk) txid pr (Gas g) lo
         tfieldLeaf "Continuation" $ text $ maybe "" tshow pcont
         tfield "Metadata" $ renderMetaData netId cid meta
         tfield "Events" $ elClass "table" "ui definition table" $ el "tbody" $
-                forM_ evs $ \ ev -> el "tr" $ do
-                  elClass "td" "two wide" $ mapM_ text (getEventName ev)
-                  elClass "td" "evtd leaf-cell" $ elClass "table" "evtable" $
+                forM_ evs $ \ ev -> tfieldLeaf (fromMaybe "" (getEventName ev)) $
+                  elClass "table" "evtable" $
                     forM_ (Compose $ getEventParams ev) $ \v ->
                       elClass "tr" "evtable" $ elClass "td" "evtable" $
                         text $ unwrapJSON v

--- a/frontend/src/Frontend/Page/TxDetail.hs
+++ b/frontend/src/Frontend/Page/TxDetail.hs
@@ -148,9 +148,8 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
               widgetHold_ (inlineLoader "Querying continuation info...") (renderCont c . ditchPartialResult <$> res)
           tfieldLeaf "Transaction ID" $ text $ tshow $ _txDetail_txid firstTx
       tfield "Events" $ elClass "table" "ui definition table" $ el "tbody" $
-        forM_ (_txDetail_events firstTx) $ \ ev -> el "tr" $ do
-          elClass "td" "two wide" $ text (_txEvent_name ev)
-          elClass "td" "evtd leaf-cell" $ elClass "table" "evtable" $
+        forM_ (_txDetail_events firstTx) $ \ ev ->
+          tfieldLeaf (_txEvent_name ev) $ elClass "table" "evtable" $
             forM_ (_txEvent_params ev) $ \v ->
               elClass "tr" "evtable" $ elClass "td" "evtable" $ text $ pactValueJSON v
 
@@ -176,19 +175,13 @@ txDetailPage nc netId cwVer txs@(firstTx NE.:| restTxs) = do
             tfield "Signature Capabilities" $ do
               when (not $ null $ _signer_capList s) $ do
                 elClass "table" "ui celled table" $ do
-                  el "thead" $ do
-                    el "tr" $ do
-                      el "th" $ text "Name"
-                      el "th" $ text "Arguments"
-
                   el "tbody" $
-                    forM_ (_signer_capList s) $ \c -> el "tr" $ do
-                      el "td" $ text $ _scName c
-                      elClass "td" "evtd leaf-cell" $ elClass "table" "evtable" $
+                    forM_ (_signer_capList s) $ \c ->
+                      tfieldLeaf (_scName c) $ elClass "table" "evtable" $
                         forM_ (_scArgs c) $ \arg -> elClass "tr" "evtable" $
-                          elClass "td" "evtable" $ text $ unwrapJSON arg
-      tfield "Signatures" $ do
-        elClass "table" "evtable leaf-cell" $
+                          elClass "td" "evtable" $ text $ pactValueJSON arg
+      tfieldLeaf "Signatures" $ do
+        elClass "table" "evtable" $
           forM_ (_txDetail_sigs firstTx) $ \s ->
             elClass "tr" "evtable" $ elClass "td" "evtable" $ text $ unSig s
   where

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -51,9 +51,11 @@ td {
     vertical-align: middle;
 }
 
-.leaf-cell {
-  overflow-x: auto;
-  max-width: 200px;
+.leaf-cell-td {
+    max-width: 200px;
+}
+.leaf-cell-div {
+    overflow-x: auto;
 }
 
 div.header-row {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -30,10 +30,6 @@ div.block-table div.spacer-row:last-child {
     display: none;
 }
 
-td.evtd {
-
-    }
-
 table.evtable {
     width: 100% !important;
     }


### PR DESCRIPTION
I've noticed that #90 didn't improve the situation much for Firefox even though it solves the issue on Chrome and Safari. This PR fixes the layout issues for Firefox as well by moving the `overflow-x:auto` into a `div` inside the `td`.

This PR also makes the "Signature Capabilities" field display consistent with the "Events" field since capabilities and events are closely related in Pact, so there's no reason to display them differently.